### PR TITLE
use regex for lanes without specified sequence tag

### DIFF
--- a/lib/Bio/VertRes/Config/CommandLine/ConstructLimits.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/ConstructLimits.pm
@@ -46,9 +46,20 @@ sub limits_hash
   {
     $limits{project} = [$self->input_id];
   }
-  elsif($self->input_type eq 'lane' || $self->input_type eq 'library' || $self->input_type eq 'sample')
+  elsif($self->input_type eq 'library' || $self->input_type eq 'sample')
   {
     $limits{$self->input_type} = [$self->input_id];
+  } 
+  elsif($self->input_type eq 'lane')
+  {
+    if($self->input_id =~ /^\d+_\d$/)
+    {
+      $limits{$self->input_type} = [$self->input_id.'(#.+)?'];
+    }
+    else
+    {
+      $limits{$self->input_type} = [$self->input_id];
+    }
   }
   elsif($self->input_type eq 'file')
   {

--- a/t/Bio/VertRes/Config/CommandLine/ConstructLimits.t
+++ b/t/Bio/VertRes/Config/CommandLine/ConstructLimits.t
@@ -59,8 +59,19 @@ is_deeply(
         species    => undef
       )->limits_hash,
     { lane => ['1234_5#6'] },
-    'Lane with name and no species'
+    'Lane with name (tag) and no species'
 );
+
+is_deeply(
+    Bio::VertRes::Config::CommandLine::ConstructLimits->new(
+        input_type => 'lane',
+        input_id   => '1234_5',
+        species    => undef
+      )->limits_hash,
+    { lane => ['1234_5(#.+)?'] },
+    'Lane with name (no tag) and no species'
+);
+
 
 is_deeply(
     Bio::VertRes::Config::CommandLine::ConstructLimits->new(


### PR DESCRIPTION
Lanes with numbering 1234_5 have regex added for tags - lanes with specified tags (1234_5#6) are unaffected.
