### PR TITLE
bacteria snp-calling with smalt defaults to --smalt_mapper_r -1

### DIFF
--- a/lib/Bio/VertRes/Config/CommandLine/BacteriaSnpCalling.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/BacteriaSnpCalling.pm
@@ -38,6 +38,7 @@ sub run {
         Bio::VertRes::Config::Recipes::BacteriaSnpCallingUsingBowtie2->new( $self->mapping_parameters )->create();
     }
     else {
+        $self->smalt_mapper_r(-1) unless defined $self->smalt_mapper_r;
         Bio::VertRes::Config::Recipes::BacteriaSnpCallingUsingSmalt->new( $self->mapping_parameters)->create();
     }
 
@@ -76,6 +77,9 @@ bacteria_snp_calling -t file -i file_of_lanes -r "Staphylococcus_aureus_subsp_au
 
 # Map and SNP call a single species in a study
 bacteria_snp_calling -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" -s "Staphylococcus aureus"
+
+# Map and SNP call specifying smalt -r parameter (defaults to -1)
+bacteria_snp_calling -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" -s "Staphylococcus aureus" -smalt_mapper_r 0
 
 # Use a different mapper. Available are bwa/stampy/smalt/ssaha2/bowtie2. The default is smalt and ssaha2 is only for 454 data.
 bacteria_snp_calling -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" -m bwa

--- a/t/Bio/VertRes/Config/CommandLine/BacteriaSnpCalling.t
+++ b/t/Bio/VertRes/Config/CommandLine/BacteriaSnpCalling.t
@@ -1,0 +1,95 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Data::Dumper;
+use File::Temp;
+use File::Slurp;
+BEGIN { unshift( @INC, './lib' ) }
+
+BEGIN {
+    use Test::Most;
+    use_ok('Bio::VertRes::Config::CommandLine::BacteriaSnpCalling');
+}
+
+my $destination_directory_obj = File::Temp->newdir( CLEANUP => 1 );
+my $destination_directory = $destination_directory_obj->dirname();
+
+open(my $copy_stdout, ">&STDOUT"); close(STDOUT); open(STDOUT, ">", "/dev/null"); # copy stdout
+
+my @input_args = qw(-t study -i ZZZ -r ABC -l t/data/refs.index -c);
+push(@input_args, $destination_directory);
+ok( my $obj_default = Bio::VertRes::Config::CommandLine::BacteriaSnpCalling->new(args => \@input_args, script_name => 'name_of_script' ), 'initialise commandline bacteria snp-calling (default)');
+ok( $obj_default->run, 'run commandline bacteria snp-calling (default)');
+my $mapping_params = $obj_default->mapping_parameters;
+$mapping_params->{config_base} = 'no need to check';
+is_deeply($mapping_params, {
+          'protocol' => 'StrandSpecificProtocol',
+          'overwrite_existing_config_file' => 0,
+          'reference_lookup_file' => 't/data/refs.index',
+          'database' => 'pathogen_prok_track',
+          'database_connect_file' => '/software/pathogen/config/database_connection_details',
+          'limits' => {
+                        'project' => [
+                                       'ZZZ'
+                                     ]
+                      },
+          'reference' => 'ABC',
+          'additional_mapper_params' => ' -r -1',
+          'root_base' => '/lustre/scratch108/pathogen/pathpipe',
+          'log_base'  => '/nfs/pathnfs05/log',
+          'config_base' => 'no need to check'
+          
+        }, 'Mapping parameters include default smalt parameters');
+
+@input_args = qw(-t study -i ZZZ -r ABC --smalt_mapper_r 0 -l t/data/refs.index -c);
+push(@input_args, $destination_directory);
+ok( my $obj_user = Bio::VertRes::Config::CommandLine::BacteriaSnpCalling->new(args => \@input_args, script_name => 'name_of_script' ), 'initialise commandline bacteria snp-calling (smalt_mapper_r = 0)');
+ok( $obj_user->run, 'run commandline bacteria snp-calling (smalt_mapper_r = 0)');
+$mapping_params = $obj_user->mapping_parameters;
+$mapping_params->{config_base} = 'no need to check';
+is_deeply($mapping_params, {
+          'protocol' => 'StrandSpecificProtocol',
+          'overwrite_existing_config_file' => 0,
+          'reference_lookup_file' => 't/data/refs.index',
+          'database' => 'pathogen_prok_track',
+          'database_connect_file' => '/software/pathogen/config/database_connection_details',
+          'limits' => {
+                        'project' => [
+                                       'ZZZ'
+                                     ]
+                      },
+          'reference' => 'ABC',
+          'additional_mapper_params' => ' -r 0',
+          'root_base' => '/lustre/scratch108/pathogen/pathpipe',
+          'log_base'  => '/nfs/pathnfs05/log',
+          'config_base' => 'no need to check'
+          
+        }, 'Mapping parameters include user smalt parameters');
+
+@input_args = qw(-t study -i ZZZ -r ABC -m bwa -l t/data/refs.index -c);
+push(@input_args, $destination_directory);
+ok( my $obj_bwa = Bio::VertRes::Config::CommandLine::BacteriaSnpCalling->new(args => \@input_args, script_name => 'name_of_script' ), 'initialise commandline bacteria snp-calling (bwa)');
+ok( $obj_bwa->run, 'run commandline bacteria snp-calling (bwa)');
+$mapping_params = $obj_bwa->mapping_parameters;
+$mapping_params->{config_base} = 'no need to check';
+is_deeply($mapping_params, {
+          'protocol' => 'StrandSpecificProtocol',
+          'overwrite_existing_config_file' => 0,
+          'reference_lookup_file' => 't/data/refs.index',
+          'database' => 'pathogen_prok_track',
+          'database_connect_file' => '/software/pathogen/config/database_connection_details',
+          'limits' => {
+                        'project' => [
+                                       'ZZZ'
+                                     ]
+                      },
+          'reference' => 'ABC',
+          'root_base' => '/lustre/scratch108/pathogen/pathpipe',
+          'log_base'  => '/nfs/pathnfs05/log',
+          'config_base' => 'no need to check'
+          
+        }, 'Mapping parameters ok for bwa');
+
+close(STDOUT); open(STDOUT, ">&", $copy_stdout); # restore stdout
+done_testing();
+


### PR DESCRIPTION
Bacteria SNP-Calling with smalt defaults to smalt mapping parameter -r -1. Reads with multiple best matches are set to unmatched.

Do not merge this request until researchers informed.
