### PR TITLE
bacteria mapping and snp-calling with smalt defaults to -r -1

### DIFF
--- a/lib/Bio/VertRes/Config/CommandLine/BacteriaMapping.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/BacteriaMapping.pm
@@ -85,13 +85,16 @@ bacteria_mapping -t file -i file_of_lanes -r "Staphylococcus_aureus_subsp_aureus
 # Map a single species in a study
 bacteria_mapping -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" -s "Staphylococcus aureus"
 
+# Map and SNP call specifying smalt -r parameter (defaults to -1)
+bacteria_snp_calling -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" -s "Staphylococcus aureus" -smalt_mapper_r 0
+
 # Use a different mapper. Available are bwa/stampy/smalt/ssaha2/bowtie2/tophat. The default is smalt and ssaha2 is only for 454 data.
 bacteria_mapping -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" -m bwa
 
 # Vary the parameters for smalt
 # Index defaults to '-k 13 -s 4'
-# Mapping defaults to '-r 0 -x -y 0.8'
-bacteria_mapping -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" --smalt_index_k 13 --smalt_index_s 4 --smalt_mapper_r 0 --smalt_mapper_y 0.8 --smalt_mapper_x
+# Mapping defaults to '-r -1 -x -y 0.8'
+bacteria_mapping -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" --smalt_index_k 13 --smalt_index_s 4 --smalt_mapper_r -1 --smalt_mapper_y 0.8 --smalt_mapper_x
 
 # Set orientation of mate pairs for smalt ('pe', 'mp' or 'pp')
 bacteria_mapping -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" --smalt_mapper_l pp

--- a/lib/Bio/VertRes/Config/CommandLine/BacteriaSnpCalling.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/BacteriaSnpCalling.pm
@@ -77,6 +77,9 @@ bacteria_snp_calling -t file -i file_of_lanes -r "Staphylococcus_aureus_subsp_au
 # Map and SNP call a single species in a study
 bacteria_snp_calling -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" -s "Staphylococcus aureus"
 
+# Map and SNP call specifying smalt -r parameter (defaults to -1)
+bacteria_snp_calling -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" -s "Staphylococcus aureus" -smalt_mapper_r 0
+
 # Use a different mapper. Available are bwa/stampy/smalt/ssaha2/bowtie2. The default is smalt and ssaha2 is only for 454 data.
 bacteria_snp_calling -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" -m bwa
 

--- a/lib/Bio/VertRes/Config/Recipes/BacteriaMappingUsingSmalt.pm
+++ b/lib/Bio/VertRes/Config/Recipes/BacteriaMappingUsingSmalt.pm
@@ -23,7 +23,7 @@ with 'Bio::VertRes::Config::Recipes::Roles::Reference';
 with 'Bio::VertRes::Config::Recipes::Roles::CreateGlobal';
 with 'Bio::VertRes::Config::Recipes::Roles::BacteriaMapping';
 
-has 'additional_mapper_params' => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'additional_mapper_params' => ( is => 'ro', isa => 'Maybe[Str]', default => '-r -1' );
 has 'mapper_index_params'      => ( is => 'ro', isa => 'Maybe[Str]' );
 
 

--- a/lib/Bio/VertRes/Config/Recipes/BacteriaSnpCallingUsingSmalt.pm
+++ b/lib/Bio/VertRes/Config/Recipes/BacteriaSnpCallingUsingSmalt.pm
@@ -29,7 +29,7 @@ with 'Bio::VertRes::Config::Recipes::Roles::Reference';
 with 'Bio::VertRes::Config::Recipes::Roles::CreateGlobal';
 with 'Bio::VertRes::Config::Recipes::Roles::BacteriaSnpCalling';
 
-has 'additional_mapper_params' => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'additional_mapper_params' => ( is => 'ro', isa => 'Maybe[Str]', default => '-r -1' );
 has 'mapper_index_params'      => ( is => 'ro', isa => 'Maybe[Str]' );
 
 override '_pipeline_configs' => sub {

--- a/t/Bio/VertRes/Config/Recipes/BacteriaMappingUsingSmalt.t
+++ b/t/Bio/VertRes/Config/Recipes/BacteriaMappingUsingSmalt.t
@@ -1,0 +1,98 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Data::Dumper;
+use File::Temp;
+use File::Slurp;
+BEGIN { unshift( @INC, './lib' ) }
+
+BEGIN {
+    use Test::Most;
+    use_ok('Bio::VertRes::Config::Recipes::BacteriaMappingUsingSmalt');
+}
+
+my $destination_directory_obj = File::Temp->newdir( CLEANUP => 1 );
+my $destination_directory = $destination_directory_obj->dirname();
+
+ok(
+    (
+        my $obj = Bio::VertRes::Config::Recipes::BacteriaMappingUsingSmalt->new(
+            database    => 'my_database',
+            config_base => $destination_directory,
+            database_connect_file => 't/data/database_connection_details',
+            limits      => { project => ['ABC study( EFG )'] },
+            reference_lookup_file => 't/data/refs.index',
+            reference             => 'ABC'
+        )
+    ),
+    'initalise creating files'
+);
+ok( ( $obj->create ), 'Create all the config files and toplevel files' );
+
+# Are all the nessisary top level files there?
+ok( -e $destination_directory . '/my_database/my_database.ilm.studies' , 'study names file exists');
+ok( -e $destination_directory . '/my_database/my_database_stored_pipeline.conf', 'stored toplevel file');
+ok( -e $destination_directory . '/my_database/my_database_import_pipeline.conf', 'import toplevel file');
+ok( -e $destination_directory . '/my_database/my_database_qc_pipeline.conf', 'qc toplevel file');
+ok( -e $destination_directory . '/my_database/my_database_mapping_pipeline.conf', 'mapping toplevel file');
+
+
+# Individual config files
+ok((-e "$destination_directory/my_database/stored/stored_global.conf"), 'stored config file exists');
+ok((-e "$destination_directory/my_database/import/import_global.conf"), 'import config file exists');
+ok((-e "$destination_directory/my_database/qc/qc_ABC_study_EFG.conf"), 'QC config file exists' );
+ok((-e "$destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_smalt.conf"), 'mapping config file exists' );
+
+
+my $text = read_file( "$destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_smalt.conf" );
+my $input_config_file = eval($text);
+$input_config_file->{prefix} = '_checked_elsewhere_';
+is_deeply($input_config_file,{
+  'db' => {
+            'database' => 'my_database',
+            'password' => 'some_password',
+            'user' => 'some_user',
+            'port' => 1234,
+            'host' => 'some_hostname'
+          },
+  'data' => {
+              'mark_duplicates' => 1,
+              'do_recalibration' => 0,
+              'db' => {
+                        'database' => 'my_database',
+                        'password' => 'some_password',
+                        'user' => 'some_user',
+                        'port' => 1234,
+                        'host' => 'some_hostname'
+                      },
+              'get_genome_coverage' => 1,
+              'dont_wait' => 0,
+              'assembly_name' => 'ABC',
+              'exit_on_errors' => 0,
+              'add_index' => 1,
+              'reference' => '/path/to/ABC.fa',
+              'do_cleanup' => 1,
+              'ignore_mapped_status' => 1,
+              'additional_mapper_params' => '-r -1',
+              'slx_mapper' => 'smalt',
+              'slx_mapper_exe' => '/software/pathogen/external/apps/usr/local/smalt-0.7.4/smalt_x86_64'
+            },
+  'limits' => {
+                'project' => [
+                               'ABC\ study\(\ EFG\ \)'
+                             ]
+              },
+  'vrtrack_processed_flags' => {
+                                 'qc' => 1,
+                                 'stored' => 1,
+                                 'import' => 1
+                               },
+  'log' => '/nfs/pathnfs05/log/my_database/mapping_ABC_study_EFG_ABC_smalt.log',
+  'root' => '/lustre/scratch108/pathogen/pathpipe/my_database/seq-pipelines',
+  'prefix' => '_checked_elsewhere_',
+  'dont_use_get_lanes' => 1,
+  'module' => 'VertRes::Pipelines::Mapping'
+},'Mapping Config file as expected');
+
+
+done_testing();

--- a/t/Bio/VertRes/Config/Recipes/BacteriaSnpCallingUsingSmalt.t
+++ b/t/Bio/VertRes/Config/Recipes/BacteriaSnpCallingUsingSmalt.t
@@ -201,6 +201,7 @@ is_deeply($input_config_file,{
               'ignore_mapped_status' => 1,
               'slx_mapper' => 'smalt',
               'slx_mapper_exe' => '/software/pathogen/external/apps/usr/local/smalt-0.7.4/smalt_x86_64',
+              'additional_mapper_params' => '-r -1',
             },
   'limits' => {
                 'project' => [


### PR DESCRIPTION
Bacteria SNP-Calling and bacteria mapping with smalt default to smalt mapping parameter -r -1. Reads with multiple best matches are set to unmatched.

Do not merge this request until researchers informed.