### PR TITLE
Change log location

### DIFF
--- a/bin/setup_global_configs
+++ b/bin/setup_global_configs
@@ -41,6 +41,9 @@ $overwrite_existing_config_file ||= 0;
 $regeneration_log_file ||= join('/',($log_base,'command_line.log'));
 $database_connect_file = '/software/pathogen/config/database_connection_details' unless defined $database_connect_file;
 
+	print "CONFIG_BASE ".$config_base."\n";
+	print "LOG_BASE ".$log_base."\n";
+
 $log_params->log_file($regeneration_log_file);
 $log_params->create();
 

--- a/bin/setup_global_configs
+++ b/bin/setup_global_configs
@@ -38,7 +38,7 @@ $config_base           ||= '/nfs/pathnfs05/conf';
 $root_base             ||= '/lustre/scratch108/pathogen/pathpipe';
 $log_base              ||= '/nfs/pathnfs05/log';
 $overwrite_existing_config_file ||= 0;
-$regeneration_log_file ||= join('/',($config_base,'command_line.log'));
+$regeneration_log_file ||= join('/',($log_base,'command_line.log'));
 $database_connect_file = '/software/pathogen/config/database_connection_details' unless defined $database_connect_file;
 
 $log_params->log_file($regeneration_log_file);

--- a/lib/Bio/VertRes/Config/CommandLine/Common.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/Common.pm
@@ -160,9 +160,6 @@ sub BUILD {
     $self->no_ass($no_ass) if ( defined $no_ass );
     $self->test_mode($test_mode) if ( defined $test_mode );
 
-	print "CONFIG_BASE ".$self->config_base()."\n";
-	print "LOG_BASE ".$self->log_base()."\n";
-
     $regeneration_log_file ||=
       join( '/', ( $self->log_base(), 'command_line.log' ) );
     $self->regeneration_log_file($regeneration_log_file)

--- a/lib/Bio/VertRes/Config/CommandLine/Common.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/Common.pm
@@ -67,6 +67,9 @@ has 'tophat_mapper_library_type' =>
 has 'assembler' => ( is => 'rw', isa => 'Maybe[Str]' );
 has 'no_ass'    => ( is => 'rw', isa => 'Bool' );
 
+# test mode
+has 'test_mode' => ( is => 'rw', isa => 'Bool', default => 0);
+
 sub BUILD {
     my ($self) = @_;
     my $log_params = Bio::VertRes::Config::CommandLine::LogParameters->new(
@@ -88,7 +91,8 @@ sub BUILD {
         $tophat_mapper_g,                $tophat_mapper_library_type,
         $assembler,                      $root_base,
         $log_base,                       $database_connect_file,
-        $no_ass,                         $help
+        $no_ass,                         $help,
+        $test_mode
     );
 
     GetOptionsFromArray(
@@ -120,6 +124,7 @@ sub BUILD {
         'log_base=s'                     => \$log_base,
         'db_file:s'                      => \$database_connect_file,
         'no_aa'                          => \$no_ass,
+        'test'							 => \$test_mode,
         'h|help'                         => \$help
     );
 
@@ -153,16 +158,23 @@ sub BUILD {
     $self->database_connect_file($database_connect_file)
       if ( defined($database_connect_file) );
     $self->no_ass($no_ass) if ( defined $no_ass );
+    $self->test_mode($test_mode) if ( defined $test_mode );
+
+	print "CONFIG_BASE ".$self->config_base()."\n";
+	print "LOG_BASE ".$self->log_base()."\n";
 
     $regeneration_log_file ||=
-      join( '/', ( $self->log_base, 'command_line.log' ) );
+      join( '/', ( $self->log_base(), 'command_line.log' ) );
     $self->regeneration_log_file($regeneration_log_file)
       if ( defined($regeneration_log_file) );
     $self->overwrite_existing_config_file($overwrite_existing_config_file)
       if ( defined($overwrite_existing_config_file) );
 
     $log_params->log_file( $self->regeneration_log_file );
-    $log_params->create();
+    # Only create log files if not in test mode
+    if(!$self->test_mode()){
+    	$log_params->create();
+    }
 }
 
 sub _construct_smalt_index_params {
@@ -257,7 +269,8 @@ sub mapping_parameters {
         reference                      => $self->reference,
         overwrite_existing_config_file => $self->overwrite_existing_config_file,
         protocol                       => $self->protocol,
-        database_connect_file          => $self->database_connect_file
+        database_connect_file          => $self->database_connect_file,
+        regeneration_log_file		   => $self->regeneration_log_file,
     );
 
     if ( defined( $self->_construct_smalt_index_params ) ) {

--- a/lib/Bio/VertRes/Config/CommandLine/Common.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/Common.pm
@@ -155,7 +155,7 @@ sub BUILD {
     $self->no_ass($no_ass) if ( defined $no_ass );
 
     $regeneration_log_file ||=
-      join( '/', ( $self->config_base, 'command_line.log' ) );
+      join( '/', ( $self->log_base, 'command_line.log' ) );
     $self->regeneration_log_file($regeneration_log_file)
       if ( defined($regeneration_log_file) );
     $self->overwrite_existing_config_file($overwrite_existing_config_file)

--- a/t/Bio/VertRes/Config/CommandLine/Common.t
+++ b/t/Bio/VertRes/Config/CommandLine/Common.t
@@ -14,11 +14,10 @@ BEGIN {
 my $destination_directory_obj = File::Temp->newdir( CLEANUP => 1 );
 my $destination_directory = $destination_directory_obj->dirname();
 
-my @input_args = qw(-t study -i ZZZ -r ABC -m smalt --smalt_index_k 15 --smalt_index_s 4 --smalt_mapper_r 1 --smalt_mapper_y 0.9 --smalt_mapper_x --smalt_mapper_l pe -c);
-push(@input_args, $destination_directory);
+#*-----------------------------------------------------------------
+my @input_args = qw(--test -t study -i ZZZ -r ABC -m smalt --smalt_index_k 15 --smalt_index_s 4 --smalt_mapper_r 1 --smalt_mapper_y 0.9 --smalt_mapper_x --smalt_mapper_l pe);
 ok( my $obj = Bio::VertRes::Config::CommandLine::Common->new(args => \@input_args, script_name => 'name_of_script' ), 'initialise commandline common obj');
 my $mapping_params = $obj->mapping_parameters;
-$mapping_params->{config_base} = 'no need to check';
 is_deeply($mapping_params, {
           'protocol' => 'StrandSpecificProtocol',
           'overwrite_existing_config_file' => 0,
@@ -35,12 +34,13 @@ is_deeply($mapping_params, {
           'additional_mapper_params' => ' -r 1 -y 0.9 -x -l pe',
           'root_base' => '/lustre/scratch108/pathogen/pathpipe',
           'log_base'  => '/nfs/pathnfs05/log',
-          'config_base' => 'no need to check'
+          'config_base' => '/nfs/pathnfs05/conf',
+          'regeneration_log_file' => '/nfs/pathnfs05/log/command_line.log',
           
         }, 'Mapping parameters include smalt parameters');
 
-@input_args = qw(-t study -i ZZZ -r ABC -m smalt --smalt_mapper_l xxx -c);
-push(@input_args, $destination_directory);
+#*-----------------------------------------------------------------
+@input_args = qw(--test -t study -i ZZZ -r ABC -m smalt --smalt_mapper_l xxx);
 throws_ok(
     sub {
         Bio::VertRes::Config::CommandLine::Common->new(args => \@input_args, script_name => 'name_of_script' )->_construct_smalt_additional_mapper_params;
@@ -49,11 +49,10 @@ throws_ok(
     'Invalid --smalt_mapper_l throws an error'
 );
 
-@input_args = qw(-t study -i ZZZ -r ABC -m tophat --tophat_mapper_max_intron 50000 --tophat_mapper_min_intron 70 --tophat_mapper_max_multihit 20 -c);
-push(@input_args, $destination_directory);
+#*-----------------------------------------------------------------
+@input_args = qw(--test -t study -i ZZZ -r ABC -m tophat --tophat_mapper_max_intron 50000 --tophat_mapper_min_intron 70 --tophat_mapper_max_multihit 20);
 ok( my $obj_tophat = Bio::VertRes::Config::CommandLine::Common->new(args => \@input_args, script_name => 'name_of_script' ), 'initialise commandline common obj');
 $mapping_params = $obj_tophat->mapping_parameters;
-$mapping_params->{config_base} = 'no need to check';
 is_deeply($mapping_params, {
           'protocol' => 'StrandSpecificProtocol',
           'overwrite_existing_config_file' => 0,
@@ -69,15 +68,15 @@ is_deeply($mapping_params, {
           'additional_mapper_params' => ' -I 50000 -i 70 -g 20',
           'root_base' => '/lustre/scratch108/pathogen/pathpipe',
           'log_base'  => '/nfs/pathnfs05/log',
-          'config_base' => 'no need to check'
-          
+          'config_base' => '/nfs/pathnfs05/conf',
+          'regeneration_log_file' => '/nfs/pathnfs05/log/command_line.log',
+                    
         }, 'Mapping parameters include tophat parameters');
 
-@input_args = qw(-t study -i ZZZ -r ABC --root_base /path/to/root --log_base /path/to/log -c);
-push(@input_args, $destination_directory);
+#*-----------------------------------------------------------------
+@input_args = qw(--test -t study -i ZZZ -r ABC --root_base /path/to/root --config_base /path/to/conf --log_base /path/to/log);
 ok( my $user_root = Bio::VertRes::Config::CommandLine::Common->new(args => \@input_args, script_name => 'name_of_script' ), 'initialise commandline common obj with user-defined root and log');
 $mapping_params = $user_root->mapping_parameters;
-$mapping_params->{config_base} = 'no need to check';
 is_deeply($mapping_params, {
           'protocol' => 'StrandSpecificProtocol',
           'overwrite_existing_config_file' => 0,
@@ -92,15 +91,15 @@ is_deeply($mapping_params, {
           'reference' => 'ABC',
           'root_base' => '/path/to/root',
           'log_base'  => '/path/to/log',
-          'config_base' => 'no need to check'
+          'config_base' => '/path/to/conf',
+          'regeneration_log_file' => '/path/to/log/command_line.log',
           
-        }, 'Mapping parameters include user-defined root and log');
+        }, 'Mapping parameters include user-defined root, log and config base');
 
-@input_args = qw(-t study -i ZZZ -r ABC --db_file /user/database/connect/file -c);
-push(@input_args, $destination_directory);
+#*-----------------------------------------------------------------
+@input_args = qw(--test -t study -i ZZZ -r ABC --db_file /user/database/connect/file);
 ok( my $user_dbconnect = Bio::VertRes::Config::CommandLine::Common->new(args => \@input_args, script_name => 'name_of_script' ), 'initialise commandline common obj with user-defined database connect file');
 $mapping_params = $user_dbconnect->mapping_parameters;
-$mapping_params->{config_base} = 'no need to check';
 is_deeply($mapping_params, {
           'protocol' => 'StrandSpecificProtocol',
           'overwrite_existing_config_file' => 0,
@@ -115,15 +114,15 @@ is_deeply($mapping_params, {
           'reference' => 'ABC',
           'root_base' => '/lustre/scratch108/pathogen/pathpipe',
           'log_base'  => '/nfs/pathnfs05/log',
-          'config_base' => 'no need to check'
+          'config_base' => '/nfs/pathnfs05/conf',
+          'regeneration_log_file' => '/nfs/pathnfs05/log/command_line.log',
           
         }, 'Mapping parameters include user-defined database connect file');
 
-@input_args = qw(-t study -i ZZZ -r ABC --db_file -c);
-push(@input_args, $destination_directory);
+#*-----------------------------------------------------------------
+@input_args = qw(--test -t study -i ZZZ -r ABC --db_file);
 ok( $user_dbconnect = Bio::VertRes::Config::CommandLine::Common->new(args => \@input_args, script_name => 'name_of_script' ), 'initialise commandline common obj with user-defined database connect file set to empty string');
 $mapping_params = $user_dbconnect->mapping_parameters;
-$mapping_params->{config_base} = 'no need to check';
 is_deeply($mapping_params, {
           'protocol' => 'StrandSpecificProtocol',
           'overwrite_existing_config_file' => 0,
@@ -138,9 +137,10 @@ is_deeply($mapping_params, {
           'reference' => 'ABC',
           'root_base' => '/lustre/scratch108/pathogen/pathpipe',
           'log_base'  => '/nfs/pathnfs05/log',
-          'config_base' => 'no need to check'
+          'config_base' => '/nfs/pathnfs05/conf',
+          'regeneration_log_file' => '/nfs/pathnfs05/log/command_line.log',
           
-        }, 'Mapping parameters include user-defined database connect file set empty string');
+        }, 'Mapping parameters include user-defined database connect file set to empty string');
 
 
 done_testing();

--- a/t/bin/log_parameters.t
+++ b/t/bin/log_parameters.t
@@ -19,11 +19,11 @@ for my $script_name (  @available_scripts ) {
     my $destination_directory_obj = File::Temp->newdir( CLEANUP => 1 );
     my $destination_directory = $destination_directory_obj->dirname();
 
-    system("./bin/$script_name -c $destination_directory >/dev/null 2>&1");
+    system("./bin/$script_name --config_base $destination_directory --log_base $destination_directory >/dev/null 2>&1");
     ok( -e $destination_directory . '/command_line.log', "log file has been created for $script_name" );
     open(my $fh, $destination_directory . '/command_line.log');
     my $line = <$fh>;
-    ok(($line =~ /^[\w]+[\s]+[\w]+[\s]+[\d]+[\s]+[\d]+:[\d]+:[\d]+[\s]+[\d]+[\s]+[\w\d]+[\s]+\.\/bin\/$script_name -c $destination_directory$/), 'correct format of log file' );
+    ok(($line =~ /^[\w]+[\s]+[\w]+[\s]+[\d]+[\s]+[\d]+:[\d]+:[\d]+[\s]+[\d]+[\s]+[\w\d]+[\s]+\.\/bin\/$script_name --config_base $destination_directory --log_base $destination_directory$/), 'correct format of log file' );
 
 }
 

--- a/t/lib/TestHelper.pm
+++ b/t/lib/TestHelper.pm
@@ -10,16 +10,19 @@ our @actual_files_found;
 # default db file to be used for testing
 our $test_database_connection_file = "t/data/database_connection_details"; 
 
+
+# Execute script and check required files are created 
 sub execute_script_and_check_output {
     my ( $script_name, $scripts_and_expected_files ) = @_;
 
     for my $script_parameters ( sort keys %$scripts_and_expected_files ) {
         my $destination_directory_obj = File::Temp->newdir( CLEANUP => 1 );
         my $destination_directory = $destination_directory_obj->dirname();
-        my $full_script = './bin/' . $script_name . ' ' . $script_parameters . " --db_file $test_database_connection_file -c $destination_directory -l t/data/refs.index";
+        my $full_script = './bin/' . $script_name . ' ' . $script_parameters . " --db_file $test_database_connection_file --config_base $destination_directory --log_base $destination_directory "; #-l t/data/refs.index ";
         system("$full_script >/dev/null 2>&1");
 
         find( { wanted => \&process_file, no_chdir => 1 }, ($destination_directory) );
+        
         my @temp_directory_stripped   = map { /$destination_directory\/(.+)/ ? $1 : $_ } sort @actual_files_found;
         my @sorted_directory_stripped = sort(@temp_directory_stripped);
         my @sorted_expected_values    = sort( @{ $scripts_and_expected_files->{$script_parameters} } );
@@ -30,6 +33,7 @@ sub execute_script_and_check_output {
     }
 }
 
+# Mock execution of script and check if required files are created
 sub mock_execute_script_and_check_output {
     my ( $script_name, $scripts_and_expected_files ) = @_;
     
@@ -37,55 +41,56 @@ sub mock_execute_script_and_check_output {
     eval("use $script_name ;");
     my $returned_values = 0;
     {
-        local *STDOUT;
-        open STDOUT, '>/dev/null' or warn "Can't open /dev/null: $!";
+          local *STDOUT;
+          open STDOUT, '>/dev/null' or warn "Can't open /dev/null: $!";
 
         for my $script_parameters ( sort keys %$scripts_and_expected_files ) {
             my $destination_directory_obj = File::Temp->newdir( CLEANUP => 1 );
             my $destination_directory = $destination_directory_obj->dirname();
 
-            my $full_script = $script_parameters . " --db_file $test_database_connection_file -c $destination_directory -l t/data/refs.index";
+            my $full_script = $script_parameters . " --db_file $test_database_connection_file --config_base $destination_directory --log_base $destination_directory -l t/data/refs.index ";
             my @input_args = split( " ", $full_script );
-
+            
             my $cmd = "$script_name->new(args => \\\@input_args, script_name => '$script_name')->run;";
             eval($cmd);
 
             find( { wanted => \&process_file, no_chdir => 1 }, ($destination_directory) );
+
             my @temp_directory_stripped   = map { /$destination_directory\/(.+)/ ? $1 : $_ } sort @actual_files_found;
             my @sorted_directory_stripped = sort(@temp_directory_stripped);
             my @sorted_expected_values    = sort( @{ $scripts_and_expected_files->{$script_parameters} } );
+
             is_deeply( \@sorted_directory_stripped, \@sorted_expected_values,
                 "files created as expected for $full_script" );
             @actual_files_found = ();
         }
-        close STDOUT;
+         close STDOUT;
     }
-    # Restore stdout.
-    open STDOUT, '>&OLDOUT' or die "Can't restore stdout: $!";
-
-    # Avoid leaks by closing the independent copies.
-    close OLDOUT or die "Can't close OLDOUT: $!";
+# Restore stdout.
+      open STDOUT, '>&OLDOUT' or die "Can't restore stdout: $!"; 
+# Avoid leaks by closing the independent copies.
+      close OLDOUT or die "Can't close OLDOUT: $!";
 }
 
-
+# Mock execution of script and check that CONTENTS of config file is as expected
 sub mock_execute_script_create_file_and_check_output {
    my ( $script_name, $scripts_and_expected_files ) = @_;
 
-   open OLDOUT, '>&STDOUT';
-   open OLDERR, '>&STDERR';
+    open OLDOUT, '>&STDOUT';
+    open OLDERR, '>&STDERR';
    eval("use $script_name ;");
    my $returned_values = 0;
    {
-		local *STDOUT;
-        open STDOUT, '>/dev/null' or warn "Can't open /dev/null: $!";
-        local *STDERR;
-        open STDERR, '>/dev/null' or warn "Can't open /dev/null: $!";
+ 		local *STDOUT;
+         open STDOUT, '>/dev/null' or warn "Can't open /dev/null: $!";
+         local *STDERR;
+         open STDERR, '>/dev/null' or warn "Can't open /dev/null: $!";
 
        for my $script_parameters ( sort keys %$scripts_and_expected_files ) {
            my $destination_directory_obj = File::Temp->newdir( CLEANUP => 1 );
            my $destination_directory = $destination_directory_obj->dirname();
 		
-		   my $full_script = $script_parameters . " --db_file $test_database_connection_file -c $destination_directory -l t/data/refs.index";
+		   my $full_script = $script_parameters . " --test --db_file $test_database_connection_file --config_base $destination_directory --log_base /nfs/pathnfs05/log -l t/data/refs.index ";
            my @input_args = split( " ", $full_script );
 
            my $cmd = "$script_name->new(args => \\\@input_args, script_name => '$script_name')->run;";
@@ -93,24 +98,23 @@ sub mock_execute_script_create_file_and_check_output {
            my $actual_output_file_name = $destination_directory . '/' . $scripts_and_expected_files->{$script_parameters}->[0];
            my $expected_output_file_name = $scripts_and_expected_files->{$script_parameters}->[1];
            ok(-e $actual_output_file_name, "Actual output file exists $actual_output_file_name");
-
-		   
+	   
 		   strip_prefix_attribute($actual_output_file_name);
            is_deeply(eval(read_file($actual_output_file_name)), eval(read_file($expected_output_file_name)), "Actual and expected output match for '$script_parameters'");
            unlink($actual_output_file_name);
 
        }
-       close STDOUT;
-       close STDERR;
+        close STDOUT;
+        close STDERR;
    }
 
    # Restore stdout.
-   open STDOUT, '>&OLDOUT' or die "Can't restore stdout: $!";
-   open STDERR, '>&OLDERR' or die "Can't restore stderr: $!";
+    open STDOUT, '>&OLDOUT' or die "Can't restore stdout: $!";
+    open STDERR, '>&OLDERR' or die "Can't restore stderr: $!";
    
    # Avoid leaks by closing the independent copies.
-   close OLDOUT or die "Can't close OLDOUT: $!";
-   close OLDERR or die "Can't close OLDERR: $!";
+    close OLDOUT or die "Can't close OLDOUT: $!";
+    close OLDERR or die "Can't close OLDERR: $!";
 }
 
 sub process_file {


### PR DESCRIPTION
Related to ticket #472034
The command_line.log file (which records the calls to these scripts) was being created in /nfs/pathnfs05/conf. 
The edits in this PR moves this file to /nfs/pathnfs05/log like all the other log files, and changes the tests accordingly. 

Changes are, broadly:

1) Change location of command_line.log from $conf_base/command_line.log to $log_base/command_line.log
2) Add a 'test_mode' to CommandLine/Command.pm to only create this log file when not in test mode
3) Run tests using the --log_base option and check the location of the command_line.log where possible
4) TestHelper.pm is the main driver for the tests. It checks three things: 

*) execute_script_and_check_output
Executes script using a system call and checks that a expected list of files (inc command_line.log file) are created on disk. So far only used
by setup_global_config.t
*) mock_execute_script_and_check_output
Mocks execution by eval'ing the run method on the script object and checks that a expected list of files (inc command_line.log file) are created on disk
*) mock_execute_script_create_file_and_check_output
Same as above, except it compares the contents of the config files created to the expected values. This is useful to check
if default paths to /nfs logs get picked up correctly without running into file creation errors. Makes use of the test mode where the 
command_line.log file is not created on disk but the config files are. 