### PR TITLE
Nds tophat frstrand option for rnaseq

### DIFF
--- a/lib/Bio/VertRes/Config/CommandLine/BacteriaRnaSeqExpression.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/BacteriaRnaSeqExpression.pm
@@ -17,6 +17,8 @@ use Bio::VertRes::Config::Recipes::BacteriaRnaSeqExpressionUsingBowtie2;
 with 'Bio::VertRes::Config::CommandLine::ReferenceHandlingRole';
 extends 'Bio::VertRes::Config::CommandLine::Common';
 
+has 'tophat_mapper_library_type' =>( is => 'rw', isa => 'Bio::VertRes::Config::TophatLib', default => 'fr-firststrand' );
+
 sub run {
     my ($self) = @_;
 

--- a/lib/Bio/VertRes/Config/CommandLine/BacteriaRnaSeqExpression.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/BacteriaRnaSeqExpression.pm
@@ -90,8 +90,8 @@ bacteria_rna_seq_expression -t study -i 1234 -r "Staphylococcus_aureus_subsp_aur
 bacteria_rna_seq_expression -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" -m smalt
 
 #Default parameters for Tophat
-#The --library_type parameter defaults to fr-unstranded. Other options are: fr-firststrand or fr-secondstrand. 
-bacteria_rna_seq_expression -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" --tophat_mapper_library_type fr-firststrand
+#The --library_type parameter defaults to fr-firststrand for rnaseq data. Other options are: fr-unstranded or fr-secondstrand. 
+bacteria_rna_seq_expression -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" --tophat_mapper_library_type fr-unstranded
 
 # Run over a study in a named database specifying location of configs
 bacteria_rna_seq_expression -t study -i 1234 -r "Staphylococcus_aureus_subsp_aureus_EMRSA15_v1" -d my_database -c /path/to/my/configs

--- a/lib/Bio/VertRes/Config/CommandLine/EukaryotesRnaSeqExpression.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/EukaryotesRnaSeqExpression.pm
@@ -92,8 +92,8 @@ eukaryote_rna_seq_expression -t study -i 1234 -r "Leishmania_donovani_21Apr2011"
 eukaryote_rna_seq_expression -t study -i 1234 -r "Leishmania_donovani_21Apr2011" -m bwa
 
 #Default parameters for Tophat
-#The --library_type parameter defaults to fr-unstranded. Other options are: fr-firststrand or fr-secondstrand. 
-eukaryote_rna_seq_expression -t study -i 1234 -r "Leishmania_donovani_21Apr2011" --tophat_mapper_library_type fr-firststrand
+#The --library_type parameter defaults to fr-firststrand for rnaseq data. Other options are: fr-unstranded or fr-secondstrand. . 
+eukaryote_rna_seq_expression -t study -i 1234 -r "Leishmania_donovani_21Apr2011" --tophat_mapper_library_type fr-unstranded
 
 # Vary the parameters for tophat
 # Mapping defaults to '-I 10000 -i 70 -g 1'

--- a/lib/Bio/VertRes/Config/CommandLine/EukaryotesRnaSeqExpression.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/EukaryotesRnaSeqExpression.pm
@@ -19,6 +19,7 @@ extends 'Bio::VertRes::Config::CommandLine::Common';
 
 has 'database'    => ( is => 'rw', isa => 'Str', default => 'pathogen_euk_track' );
 has 'protocol'    => ( is => 'rw', isa => 'Str', default => 'StandardProtocol' );
+has 'tophat_mapper_library_type' => ( is => 'rw', isa => 'Bio::VertRes::Config::TophatLib', default => 'fr-firststrand' );
 
 sub run {
     my ($self) = @_;

--- a/lib/Bio/VertRes/Config/CommandLine/HelminthRnaSeqExpression.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/HelminthRnaSeqExpression.pm
@@ -101,8 +101,8 @@ helminth_rna_seq_expression -t study -i 1234 -r "Schistosoma_mansoni_v5" --topha
 helminth_rna_seq_expression -t study -i 1234 -r "Schistosoma_mansoni_v5" -m smalt --smalt_index_k 13 --smalt_index_s 2 --smalt_mapper_r 0 --smalt_mapper_y 0.8 --smalt_mapper_x
 
 #Default parameters for Tophat
-#The --library_type parameter defaults to fr-unstranded. Other options are: fr-firststrand or fr-secondstrand. 
-helminth_rna_seq_expression -t study -i 1234 -r "Schistosoma_mansoni_v5" --tophat_mapper_library_type fr-firststrand
+#The --library_type parameter defaults to fr-firststrand for rnaseq data. Other options are: fr-unstranded or fr-secondstrand. 
+helminth_rna_seq_expression -t study -i 1234 -r "Schistosoma_mansoni_v5" --tophat_mapper_library_type fr-unstranded
 
 # Run over a study in a named database specifying location of configs
 helminth_rna_seq_expression -t study -i 1234 -r "Schistosoma_mansoni_v5" -d my_database -c /path/to/my/configs

--- a/lib/Bio/VertRes/Config/CommandLine/HelminthRnaSeqExpression.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/HelminthRnaSeqExpression.pm
@@ -19,6 +19,7 @@ extends 'Bio::VertRes::Config::CommandLine::Common';
 
 has 'database'    => ( is => 'rw', isa => 'Str', default => 'pathogen_helminth_track' );
 has 'protocol'    => ( is => 'rw', isa => 'Str', default => 'StandardProtocol' );
+has 'tophat_mapper_library_type' => ( is => 'rw', isa => 'Bio::VertRes::Config::TophatLib', default => 'fr-firststrand' );
 
 sub run {
     my ($self) = @_;

--- a/lib/Bio/VertRes/Config/CommandLine/VirusRnaSeqExpression.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/VirusRnaSeqExpression.pm
@@ -19,6 +19,7 @@ extends 'Bio::VertRes::Config::CommandLine::Common';
 
 has 'database'    => ( is => 'rw', isa => 'Str', default => 'pathogen_virus_track' );
 has 'protocol'    => ( is => 'rw', isa => 'Str', default => 'StandardProtocol' );
+has 'tophat_mapper_library_type' => ( is => 'rw', isa => 'Bio::VertRes::Config::TophatLib', default => 'fr-firststrand' );
 
 sub run {
     my ($self) = @_;

--- a/lib/Bio/VertRes/Config/CommandLine/VirusRnaSeqExpression.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/VirusRnaSeqExpression.pm
@@ -92,8 +92,8 @@ virus_rna_seq_expression -t study -i 1234 -r "Influenzavirus_A_H1N1" -s "Influen
 virus_rna_seq_expression -t study -i 1234 -r "Influenzavirus_A_H1N1" -m bwa
 
 #Default parameters for Tophat
-#The --library_type parameter defaults to fr-unstranded. Other options are: fr-firststrand or fr-secondstrand. 
-virus_rna_seq_expression -t study -i 1234 -r "Influenzavirus_A_H1N1" --tophat_mapper_library_type fr-firststrand
+#The --library_type parameter defaults to fr-firststrand for rnaseq data. Other options are: fr-unstranded or fr-secondstrand. 
+virus_rna_seq_expression -t study -i 1234 -r "Influenzavirus_A_H1N1" --tophat_mapper_library_type fr-unstranded
 
 # Run over a study in a named database specifying location of configs
 virus_rna_seq_expression -t study -i 1234 -r "Influenzavirus_A_H1N1" -d my_database -c /path/to/my/configs

--- a/t/bin/eukaryote_rna_seq_expression.t
+++ b/t/bin/eukaryote_rna_seq_expression.t
@@ -146,7 +146,7 @@ mock_execute_script_and_check_output( $script_name, \%scripts_and_expected_files
 %scripts_and_expected_files = (
     '-t study -i ZZZ -r ABC -m tophat' => [
         'eukaryotes/mapping/mapping_ZZZ_ABC_tophat.conf',
-        't/data/expected/eukaryote_mapping_ZZZ_ABC_tophat.conf'
+        't/data/expected/eukaryote_mapping_ZZZ_ABC_tophat_fstrand.conf'
     ],
 '-t study -i ZZZ -r ABC -m tophat --tophat_mapper_library_type fr-unstranded'
       => [

--- a/t/bin/helminth_rna_seq_expression.t
+++ b/t/bin/helminth_rna_seq_expression.t
@@ -147,7 +147,7 @@ mock_execute_script_and_check_output( $script_name, \%scripts_and_expected_files
 %scripts_and_expected_files = (
     '-t study -i ZZZ -r ABC -m tophat' => [
         'helminths/mapping/mapping_ZZZ_ABC_tophat.conf',
-        't/data/expected/helminth_mapping_ZZZ_ABC_tophat.conf'
+        't/data/expected/helminth_mapping_ZZZ_ABC_tophat_fstrand.conf'
     ],
 '-t study -i ZZZ -r ABC -m tophat --tophat_mapper_library_type fr-unstranded'
       => [


### PR DESCRIPTION
This PR is related to ticket 484950. Tophat has a --library-type option that defaults to fr-unstranded. These changes make the tophat call default to fr-firststrand if it is rna seq data (i.e. the *_rna_seq_expression scripts)

This has been done by setting the 'tophat_mapper_library_type' variable in the relevant modules. I have also updated the usage and tests.