### PR TITLE
NDS pacbio study config generation

### DIFF
--- a/bin/pacbio_register
+++ b/bin/pacbio_register
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+
+package Bio::VertRes::Config::Main::PacbioRegister;
+
+# ABSTRACT: Create config scripts for assembling and annotating a pacbio study
+# PODNAME: y
+
+=head1 SYNOPSIS
+
+Create config scripts for registering, assembling and annotating a pacbio study
+
+=cut
+
+BEGIN { unshift( @INC, '../lib' ) }
+BEGIN { unshift( @INC, './lib' ) }
+BEGIN { unshift( @INC, '/software/pathogen/internal/prod/lib/' ) }
+use Bio::VertRes::Config::CommandLine::PacbioRegister;
+
+Bio::VertRes::Config::CommandLine::PacbioRegister->new(args => \@ARGV, script_name => $0)->run;

--- a/lib/Bio/VertRes/Config/CommandLine/Common.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/Common.pm
@@ -73,6 +73,9 @@ has 'kraken_db' => ( is => 'rw', isa => 'Str', default => '/lustre/scratch108/pa
 has 'iva_insert_size' => (is => 'rw', isa => 'Int', default => 800);
 has 'iva_strand_bias' => (is => 'rw', isa => 'Num', default => 0);
 
+# circularisation
+has 'circularise'  => ( is => 'rw', isa => 'Bool', default => 0 );
+
 # test mode
 has 'test_mode' => ( is => 'rw', isa => 'Bool', default => 0);
 
@@ -100,7 +103,7 @@ sub BUILD {
         $no_ass,                         $help,
         $test_mode,						 $iva_qc,
         $kraken_db,	                     $iva_insert_size,
-        $iva_strand_bias,
+        $iva_strand_bias,				 $circularise,
     );
 
     GetOptionsFromArray(
@@ -135,8 +138,9 @@ sub BUILD {
         'test'							 => \$test_mode,
         'iva_qc'                         => \$iva_qc,
         'kraken_db=s'                    => \$kraken_db,
-        'iva_insert_size=i'                => \$iva_insert_size,
-        'iva_strand_bias=f'                => \$iva_strand_bias,
+        'iva_insert_size=i'              => \$iva_insert_size,
+        'iva_strand_bias=f'              => \$iva_strand_bias,
+        'circularise'					 => \$circularise,
         'h|help'                         => \$help
     );
 
@@ -177,6 +181,9 @@ sub BUILD {
     $self->kraken_db($kraken_db) if ( defined($kraken_db) ) ;
     $self->iva_insert_size($iva_insert_size) if ( defined($iva_insert_size) );
     $self->iva_strand_bias($iva_strand_bias) if ( defined($iva_strand_bias) );
+    
+    # circularise
+    $self->circularise($circularise) if ( defined($circularise) );
 
     $regeneration_log_file ||= join( '/', ( $self->log_base(), 'command_line.log' ) );
     $self->regeneration_log_file($regeneration_log_file)

--- a/lib/Bio/VertRes/Config/CommandLine/PacbioRegister.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/PacbioRegister.pm
@@ -1,0 +1,64 @@
+package Bio::VertRes::Config::CommandLine::PacbioRegister;
+
+# ABSTRACT: Create config scripts to assemble and annotate Pacbio data
+
+=head1 SYNOPSIS
+
+Create config scripts to assemble and annotate pacbio data
+
+=cut
+
+use Moose;
+use Bio::VertRes::Config::Recipes::PacbioRegister;
+with 'Bio::VertRes::Config::CommandLine::ReferenceHandlingRole';
+extends 'Bio::VertRes::Config::CommandLine::Common';
+
+has 'database'  => ( is => 'rw', isa => 'Str', default => 'pathogen_pacbio_track' );
+
+sub run {
+    my ($self) = @_;
+    
+     (($self->type && $self->id)  && !$self->help ) or die $self->usage_text;
+
+    (!$self->help) or die $self->usage_text;
+
+    #return if(handle_reference_inputs_or_exit( $self->reference_lookup_file, $self->available_references, $self->reference ) == 1);
+    
+    my %mapping_parameters = %{$self->mapping_parameters};
+    $mapping_parameters{'circularise'} = $self->circularise if defined ($self->circularise);
+   Bio::VertRes::Config::Recipes::PacbioRegister->new( \%mapping_parameters )->create();
+
+    $self->retrieving_results_text;
+};
+
+sub retrieving_results_text {
+    my ($self) = @_;
+    "";
+}
+
+sub usage_text
+{
+  my ($self) = @_;
+  $self->register_usage_text;
+}
+
+sub register_usage_text {
+    my ($self) = @_;
+    return <<USAGE;
+Usage: pacbio_register_study [options]
+Pipeline to register a pacbio study.
+
+# Register a study (assemble and annotate)
+pacbio_register_study -t study -i 1234 
+
+# This help message
+pacbio_register_study -h
+
+USAGE
+};
+
+
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;

--- a/lib/Bio/VertRes/Config/Pipelines/HgapAssembly.pm
+++ b/lib/Bio/VertRes/Config/Pipelines/HgapAssembly.pm
@@ -1,0 +1,80 @@
+package Bio::VertRes::Config::Pipelines::HgapAssembly;
+
+# ABSTRACT: A base class for generating an Assembly pipeline config file using hgap
+
+=head1 SYNOPSIS
+
+A class for generating the Assembly pipeline config file using the hgap assembler
+   use Bio::VertRes::Config::Pipelines::HgapAssembly;
+   
+   my $pipeline = Bio::VertRes::Config::Pipelines::HgapAssembly->new(database    => 'abc'
+                                                                       config_base => '/path/to/config/base',
+                                                                       limits      => { project => ['project name']);
+   $pipeline->to_hash();
+
+=cut
+
+use Moose;
+extends 'Bio::VertRes::Config::Pipelines::Assembly';
+
+has 'pipeline_short_name'  => ( is => 'ro', isa => 'Str', default => 'assembly' );
+has 'prefix'               => ( is => 'ro', isa => 'Bio::VertRes::Config::Prefix', default => '_hgap_' );
+has 'module'               => ( is => 'ro', isa => 'Str', default => 'VertRes::Pipelines::PacbioAssembly' );
+has '_assembler'           => ( is => 'ro', isa => 'Str',  default => 'hgap' );
+has '_assembler_exec'      => ( is => 'ro', isa => 'Str',  default => '/software/pathogen/internal/prod/bin/pacbio_assemble_smrtanalysis' );
+has '_improve_assembly'    => ( is => 'ro', isa => 'Bool', default => 0 );
+has '_optimiser_exec'      => ( is => 'ro', isa => 'Str', default => '' );
+has 'kraken_db'		   	   => ( is => 'ro', isa => 'Str',  default => '' ); # not relevant at the moment
+has '_primers_file'        => ( is => 'ro', isa => 'Str',  default => '' ); # not relevant
+has '_threads'         => ( is => 'ro', isa => 'Int',  default => 16 );
+has '_queue'			   => ( is => 'ro', isa => 'Str', default => 'normal');
+has '_genome_size'         => ( is => 'ro', isa => 'Int', default => 3000000 );
+has '_memory'         	   => ( is => 'ro', isa => 'Int', default => 100000 );
+has '_target_coverage'	   => ( is => 'ro', isa => 'Int', default => 30 );
+has '_no_bsub'			   => ( is => 'ro', isa => 'Bool', default => 1 );
+has 'circularise'		   => ( is => 'ro', isa => 'Bool', default => 0 );
+
+has '_vrtrack_processed_flags'    => ( is => 'ro', isa => 'HashRef', default => sub {{ stored => 1, assembled => 0 }} );
+
+has '_pipeline_version'    => ( is => 'rw', isa => 'Str',  lazy_build => 1 );
+has '_flag'                => ( is => 'ro', isa => 'Str',  lazy_build => 1 );
+
+
+sub _build__flag {
+    my $self = shift;
+    my $flag = $self->_error_correct . 
+               $self->_normalise .
+               $self->_remove_primers .
+               $self->_improve_assembly;
+    return $flag;
+}
+
+sub _build__pipeline_version {
+    my $self = shift;
+    my %subversions = %{ $self->_subversions };
+
+    my $version = '7' . $subversions{$self->_flag};
+    $self->_pipeline_version($version);
+}
+
+
+override 'to_hash' => sub {
+    my ($self) = @_;
+    my $output_hash = super();
+
+	$output_hash->{data}{module} = $self->module;
+	$output_hash->{data}{pipeline_version} = $self->_pipeline_version;
+    $output_hash->{data}{queue} = $self->_queue;
+    $output_hash->{data}{memory} = $self->_memory;
+    $output_hash->{data}{target_coverage} = $self->_target_coverage;
+    $output_hash->{data}{no_bsub} = $self->_no_bsub;
+    $output_hash->{data}{circularise} = $self->circularise;
+    $output_hash->{data}{threads} = $self->_threads;
+
+    return $output_hash;
+};
+
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;

--- a/lib/Bio/VertRes/Config/Recipes/PacbioRegister.pm
+++ b/lib/Bio/VertRes/Config/Recipes/PacbioRegister.pm
@@ -1,0 +1,57 @@
+package Bio::VertRes::Config::Recipes::PacbioRegister;
+# ABSTRACT: Register a pacbio study (i.e. creates assembly and annotation config files)
+
+=head1 SYNOPSIS
+
+Register a pacbio study
+   use Bio::VertRes::Config::Recipes::PacbioRegister;
+
+   my $obj = Bio::VertRes::Config::Recipes::PacbioRegister->new(
+     database => 'abc',
+     limits => {project => ['Study ABC']},
+     reference => 'ABC',
+     reference_lookup_file => '/path/to/refs.index');
+   $obj->create;
+
+=cut
+
+use Moose;
+use Bio::VertRes::Config::RegisterStudy;
+extends 'Bio::VertRes::Config::Recipes::Common';
+with 'Bio::VertRes::Config::Recipes::Roles::PacbioRegisterStudy';
+#with 'Bio::VertRes::Config::Recipes::Roles::Reference';
+with 'Bio::VertRes::Config::Recipes::Roles::CreateGlobal';
+
+has 'assembler'                   => ( is => 'ro', isa => 'Str',  default => 'hgap' );
+has 'no_ass'                      => ( is => 'ro', isa => 'Bool', default => 0 );
+has '_pipeline_version'           => ( is => 'ro', isa => 'Str' );
+has '_kingdom'                    => ( is => 'ro', isa => 'Str',  default => "Bacteria" );
+has '_vrtrack_processed_flags'    => ( is => 'ro', isa => 'HashRef', default => sub {{ assembled => 0, stored => 1}} );
+has '_max_threads'         => ( is => 'ro', isa => 'Int',  default => 16 );
+has '_queue'			   => ( is => 'ro', isa => 'Str', default => 'normal');
+has '_genome_size'         => ( is => 'ro', isa => 'Int', default => 3000000 );
+has '_memory'         	   => ( is => 'ro', isa => 'Int', default => 100000 ); # for assembly bsub job
+has '_memory_in_mb'		   => ( is => 'ro', isa => 'Int', default => 4000 ); # for annotation
+has '_target_coverage'	   => ( is => 'ro', isa => 'Int', default => 30 );
+has '_no_bsub'			   => ( is => 'ro', isa => 'Bool', default => 1 );
+has 'circularise'		   => ( is => 'ro', isa => 'Bool', default => 0 );
+
+
+override '_pipeline_configs' => sub {
+    my ($self) = @_;
+    my @pipeline_configs;
+   
+    if($self->assembler eq 'hgap')
+    {
+        $self->add_hgap_assembly_config(\@pipeline_configs);
+    }
+ 
+    $self->add_bacteria_annotate_config(\@pipeline_configs);
+
+    return \@pipeline_configs;
+};
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+

--- a/lib/Bio/VertRes/Config/Recipes/Roles/PacbioRegisterStudy.pm
+++ b/lib/Bio/VertRes/Config/Recipes/Roles/PacbioRegisterStudy.pm
@@ -1,0 +1,90 @@
+package Bio::VertRes::Config::Recipes::Roles::PacbioRegisterStudy;
+# ABSTRACT: Moose Role for registering a pacbio study
+
+=head1 SYNOPSIS
+
+Moose Role for registering a pacbio study
+
+   with 'Bio::VertRes::Config::Recipes::Roles::PacbioRegisterStudy';
+
+=method create
+
+Hooks into the create method after the base method is run to register a study
+
+=method 
+
+=cut
+
+use Moose::Role;
+use Bio::VertRes::Config::Pipelines::HgapAssembly;
+use Bio::VertRes::Config::RegisterStudy;
+
+# Register all the studies passed in the project limits array
+after 'create' => sub {
+  my ($self) = @_;
+  
+  if(defined($self->limits->{project}))
+  {
+    for my $study_name ( @{$self->limits->{project}} )
+    {
+      my $pipeline = Bio::VertRes::Config::RegisterStudy->new(
+        database    => $self->database,
+        study_name  => $study_name,
+        config_base => $self->config_base
+      );
+      $pipeline->register_study_name();
+    }
+  }
+};
+
+sub add_hgap_assembly_config
+{
+  my ($self, $pipeline_configs_array) = @_;
+  push(
+      @{$pipeline_configs_array},
+      Bio::VertRes::Config::Pipelines::HgapAssembly->new(
+          database                       => $self->database,
+          database_connect_file          => $self->database_connect_file,
+          config_base                    => $self->config_base,
+          root_base                      => $self->root_base,
+          log_base                       => $self->log_base,
+          overwrite_existing_config_file => $self->overwrite_existing_config_file,
+          limits                         => $self->limits,
+          _queue						 => $self->_queue,
+          _memory						 => $self->_memory,
+          _target_coverage			     => $self->_target_coverage,
+          _no_bsub						 => $self->_no_bsub,
+          circularise					 => $self->circularise,
+ 
+      )
+  );
+  return ;
+}
+
+
+sub add_bacteria_annotate_config
+{
+  my ($self, $pipeline_configs_array) = @_;
+  push(
+      @{$pipeline_configs_array},
+      Bio::VertRes::Config::Pipelines::AnnotateAssembly->new(
+          database                       => $self->database,
+          database_connect_file          => $self->database_connect_file,
+          root_base                      => $self->root_base,
+          log_base                       => $self->log_base,
+          config_base                    => $self->config_base,
+          overwrite_existing_config_file => $self->overwrite_existing_config_file,
+          limits                         => $self->limits,
+          _kingdom                       => $self->_kingdom,
+          _assembler                     => $self->assembler,
+          _memory_in_mb					 => $self->_memory_in_mb,
+      )
+  );
+  return ;
+}
+
+
+no Moose;
+1;
+
+

--- a/t/bin/pacbio_register.t
+++ b/t/bin/pacbio_register.t
@@ -1,0 +1,53 @@
+#!/usr/bin/env perl
+package Bio::VertRes::Config::Tests;
+use Moose;
+use Data::Dumper;
+use File::Temp;
+
+use File::Find;
+use Test::Most;
+
+BEGIN { unshift( @INC, './lib' ) }
+BEGIN { unshift( @INC, './t/lib' ) }
+with 'TestHelper';
+
+my $script_name = 'Bio::VertRes::Config::CommandLine::PacbioRegister';
+
+my %scripts_and_expected_files = (
+    '-a ABC '                  => ['command_line.log'],
+    '-t study -i ZZZ' => [
+        'command_line.log',
+        'pathogen_pacbio_track/annotate_assembly/annotate_assembly_ZZZ_hgap.conf',
+        'pathogen_pacbio_track/assembly/assembly_ZZZ_hgap.conf',
+        'pathogen_pacbio_track/import_cram/import_cram_global.conf',
+        'pathogen_pacbio_track/pathogen_pacbio_track.ilm.studies',       
+        'pathogen_pacbio_track/pathogen_pacbio_track_annotate_assembly_pipeline.conf',
+        'pathogen_pacbio_track/pathogen_pacbio_track_assembly_pipeline.conf',
+        'pathogen_pacbio_track/pathogen_pacbio_track_import_cram_pipeline.conf',
+        'pathogen_pacbio_track/pathogen_pacbio_track_stored_pipeline.conf',
+        'pathogen_pacbio_track/stored/stored_global.conf',        
+    ],
+);
+
+mock_execute_script_and_check_output( $script_name, \%scripts_and_expected_files );
+
+
+# Check the format of assembly and annotate config file
+%scripts_and_expected_files = (
+    '-t study -i ZZZ' => [
+        'pathogen_pacbio_track/assembly/assembly_ZZZ_hgap.conf',
+        't/data/expected/assembly_ZZZ_hgap.conf'
+    ],
+    '-t study -i ZZZ' => [
+        'pathogen_pacbio_track/annotate_assembly/annotate_assembly_ZZZ_hgap.conf',
+        't/data/expected/annotate_assembly_ZZZ_hgap.conf'
+    ],
+);
+
+
+mock_execute_script_create_file_and_check_output( $script_name,
+    \%scripts_and_expected_files );
+
+
+done_testing();
+

--- a/t/bin/pacbio_register.t
+++ b/t/bin/pacbio_register.t
@@ -38,6 +38,10 @@ mock_execute_script_and_check_output( $script_name, \%scripts_and_expected_files
         'pathogen_pacbio_track/assembly/assembly_ZZZ_hgap.conf',
         't/data/expected/assembly_ZZZ_hgap.conf'
     ],
+     '-t study -i ZZZ -circularise' => [
+        'pathogen_pacbio_track/assembly/assembly_ZZZ_hgap.conf',
+        't/data/expected/assembly_ZZZ_hgap_circularise.conf'
+    ],
     '-t study -i ZZZ' => [
         'pathogen_pacbio_track/annotate_assembly/annotate_assembly_ZZZ_hgap.conf',
         't/data/expected/annotate_assembly_ZZZ_hgap.conf'

--- a/t/data/expected/annotate_assembly_ZZZ_hgap.conf
+++ b/t/data/expected/annotate_assembly_ZZZ_hgap.conf
@@ -1,0 +1,45 @@
+{
+  'max_failures' => 3,
+  'db' => {
+            'database' => 'pathogen_pacbio_track',
+            'password' => 'some_password',
+            'user' => 'some_user',
+            'port' => 1234,
+            'host' => 'some_hostname'
+          },
+  'data' => {
+              'db' => {
+                        'database' => 'pathogen_pacbio_track',
+                        'password' => 'some_password',
+                        'user' => 'some_user',
+                        'port' => 1234,
+                        'host' => 'some_hostname'
+                      },
+              'kingdom' => 'Bacteria',
+              'annotation_tool' => 'Prokka',
+              'dont_wait' => 0,
+              'assembler' => 'hgap',
+              'memory' => 4000,
+              'tmp_directory' => '/lustre/scratch108/pathogen/pathpipe/tmp',
+              'dbdir' => '/lustre/scratch108/pathogen/pathpipe/prokka',
+              'pipeline_version' => 1
+            },
+  'max_lanes_to_search' => 10000,
+  'limits' => {
+                'project' => [
+                               'ZZZ'
+                             ]
+              },
+  'octal_permissions' => 488,
+  'unix_group' => 'pathogen',
+  'vrtrack_processed_flags' => {
+                                 'assembled' => 1,
+                                 'annotated' => 0
+                               },
+  'limit' => 1000,
+  'root' => '/lustre/scratch108/pathogen/pathpipe/pathogen_pacbio_track/seq-pipelines',
+  'log' => '/nfs/pathnfs05/log/pathogen_pacbio_track/annotate_assembly_ZZZ_hgap.log',
+  'umask' => 23,
+  'module' => 'VertRes::Pipelines::AnnotateAssembly',
+  'prefix' => '_checked_elsewhere_'
+}

--- a/t/data/expected/assembly_ZZZ_hgap.conf
+++ b/t/data/expected/assembly_ZZZ_hgap.conf
@@ -1,0 +1,62 @@
+{
+  'max_failures' => 3,
+  'db' => {
+            'database' => 'pathogen_pacbio_track',
+            'password' => 'some_password',
+            'user' => 'some_user',
+            'port' => 1234,
+            'host' => 'some_hostname'
+          },
+  'data' => {
+              'remove_primers' => 0,
+              'genome_size' => 3000000,
+              'db' => {
+                        'database' => 'pathogen_pacbio_track',
+                        'password' => 'some_password',
+                        'user' => 'some_user',
+                        'port' => 1234,
+                        'host' => 'some_hostname'
+                      },
+              'improve_assembly' => 0,
+              'error_correct' => 0,
+              'assembler_exec' => '/software/pathogen/internal/prod/bin/pacbio_assemble_smrtanalysis',
+              'kraken_db' => '',
+              'primers_file' => '',
+              'assembler' => 'hgap',
+              'seq_pipeline_root' => '/lustre/scratch108/pathogen/pathpipe/pathogen_pacbio_track/seq-pipelines',
+              'normalise' => 0,
+              'sga_exec' => '/software/pathogen/external/apps/usr/bin/sga',
+              'tmp_directory' => '/lustre/scratch108/pathogen/pathpipe/tmp',
+              'pipeline_version' => '7.0.0',
+              'max_threads' => 1,
+              'module' => 'VertRes::Pipelines::PacbioAssembly',
+              'target_coverage' => 30,
+              'dont_wait' => 0,
+              'threads' => 16,
+              'no_bsub' => 1,
+              'post_contig_filtering' => 300,
+              'circularise' => 0,
+              'memory' => 100000,
+              'iva_qc' => 0,
+              'optimiser_exec' => '',
+              'queue' => 'normal'
+            },
+  'max_lanes_to_search' => 10000,
+  'limits' => {
+                'project' => [
+                               'ZZZ'
+                             ]
+              },
+  'octal_permissions' => 488,
+  'unix_group' => 'pathogen',
+  'vrtrack_processed_flags' => {
+                                 'assembled' => 0,
+                                 'stored' => 1
+                               },
+  'limit' => 1000,
+  'root' => '/lustre/scratch108/pathogen/pathpipe/pathogen_pacbio_track/seq-pipelines',
+  'log' => '/nfs/pathnfs05/log/pathogen_pacbio_track/assembly_ZZZ_hgap.log',
+  'umask' => 23,
+  'module' => 'VertRes::Pipelines::PacbioAssembly',
+  'prefix' => '_checked_elsewhere_'
+}

--- a/t/data/expected/assembly_ZZZ_hgap_circularise.conf
+++ b/t/data/expected/assembly_ZZZ_hgap_circularise.conf
@@ -1,0 +1,62 @@
+{
+  'max_failures' => 3,
+  'db' => {
+            'database' => 'pathogen_pacbio_track',
+            'password' => 'some_password',
+            'user' => 'some_user',
+            'port' => 1234,
+            'host' => 'some_hostname'
+          },
+  'data' => {
+              'remove_primers' => 0,
+              'genome_size' => 3000000,
+              'db' => {
+                        'database' => 'pathogen_pacbio_track',
+                        'password' => 'some_password',
+                        'user' => 'some_user',
+                        'port' => 1234,
+                        'host' => 'some_hostname'
+                      },
+              'improve_assembly' => 0,
+              'error_correct' => 0,
+              'assembler_exec' => '/software/pathogen/internal/prod/bin/pacbio_assemble_smrtanalysis',
+              'kraken_db' => '',
+              'primers_file' => '',
+              'assembler' => 'hgap',
+              'seq_pipeline_root' => '/lustre/scratch108/pathogen/pathpipe/pathogen_pacbio_track/seq-pipelines',
+              'normalise' => 0,
+              'sga_exec' => '/software/pathogen/external/apps/usr/bin/sga',
+              'tmp_directory' => '/lustre/scratch108/pathogen/pathpipe/tmp',
+              'pipeline_version' => '7.0.0',
+              'max_threads' => 1,
+              'module' => 'VertRes::Pipelines::PacbioAssembly',
+              'target_coverage' => 30,
+              'dont_wait' => 0,
+              'threads' => 16,
+              'no_bsub' => 1,
+              'post_contig_filtering' => 300,
+              'circularise' => 1,
+              'memory' => 100000,
+              'iva_qc' => 0,
+              'optimiser_exec' => '',
+              'queue' => 'normal'
+            },
+  'max_lanes_to_search' => 10000,
+  'limits' => {
+                'project' => [
+                               'ZZZ'
+                             ]
+              },
+  'octal_permissions' => 488,
+  'unix_group' => 'pathogen',
+  'vrtrack_processed_flags' => {
+                                 'assembled' => 0,
+                                 'stored' => 1
+                               },
+  'limit' => 1000,
+  'root' => '/lustre/scratch108/pathogen/pathpipe/pathogen_pacbio_track/seq-pipelines',
+  'log' => '/nfs/pathnfs05/log/pathogen_pacbio_track/assembly_ZZZ_hgap.log',
+  'umask' => 23,
+  'module' => 'VertRes::Pipelines::PacbioAssembly',
+  'prefix' => '_checked_elsewhere_'
+}


### PR DESCRIPTION
This PR is to add functionality to generate individual assembly and annotation config files for pacbio studies. This involves a new command line script and other modules to generate default settings for hgap and prokka to run. They also have a 'circularise' option which by default is 0. It can be set by using the -circularise option on the command line script. 

