### PR TITLE
change default assembler name to be pacbio

### DIFF
--- a/lib/Bio/VertRes/Config/Recipes/PacbioRegister.pm
+++ b/lib/Bio/VertRes/Config/Recipes/PacbioRegister.pm
@@ -22,7 +22,7 @@ with 'Bio::VertRes::Config::Recipes::Roles::PacbioRegisterStudy';
 #with 'Bio::VertRes::Config::Recipes::Roles::Reference';
 with 'Bio::VertRes::Config::Recipes::Roles::CreateGlobal';
 
-has 'assembler'                   => ( is => 'ro', isa => 'Str',  default => 'hgap' );
+has 'assembler'                   => ( is => 'ro', isa => 'Str',  default => 'pacbio' );
 has 'no_ass'                      => ( is => 'ro', isa => 'Bool', default => 0 );
 has '_pipeline_version'           => ( is => 'ro', isa => 'Str' );
 has '_kingdom'                    => ( is => 'ro', isa => 'Str',  default => "Bacteria" );


### PR DESCRIPTION
This PR changes the default value of the 'assembler' to pacbio. This is used as the prefix for status files, and pacbio appeared more appropriate than hgap.