### PR TITLE
change default rna seq protocol for bacteria

### DIFF
--- a/lib/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingBowtie2.pm
+++ b/lib/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingBowtie2.pm
@@ -27,7 +27,7 @@ with 'Bio::VertRes::Config::Recipes::Roles::Reference';
 with 'Bio::VertRes::Config::Recipes::Roles::CreateGlobal';
 with 'Bio::VertRes::Config::Recipes::Roles::BacteriaRnaSeqExpression';
 
-has 'protocol'  => ( is => 'ro', isa => 'Str',  default => 'StrandSpecificProtocol' );
+has 'protocol'  => ( is => 'ro', isa => 'Str',  default => 'StandardProtocol' );
 has '_intergenic_regions' => ( is => 'ro', isa => 'Bool', default => 1 );
 has '_no_coverage_plots'  => ( is => 'ro', isa => 'Bool', default => 0 );
 has '_sequencing_file_suffix'      => ( is => 'ro', isa => 'Str',  default => 'markdup.bam' );

--- a/lib/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingBwa.pm
+++ b/lib/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingBwa.pm
@@ -27,7 +27,7 @@ with 'Bio::VertRes::Config::Recipes::Roles::Reference';
 with 'Bio::VertRes::Config::Recipes::Roles::CreateGlobal';
 with 'Bio::VertRes::Config::Recipes::Roles::BacteriaRnaSeqExpression';
 
-has 'protocol'  => ( is => 'ro', isa => 'Str',  default => 'StrandSpecificProtocol' );
+has 'protocol'  => ( is => 'ro', isa => 'Str',  default => 'StandardProtocol' );
 has '_intergenic_regions' => ( is => 'ro', isa => 'Bool', default => 1 );
 has '_no_coverage_plots'  => ( is => 'ro', isa => 'Bool', default => 0 );
 has '_sequencing_file_suffix'      => ( is => 'ro', isa => 'Str',  default => 'markdup.bam' );

--- a/lib/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingSmalt.pm
+++ b/lib/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingSmalt.pm
@@ -30,7 +30,7 @@ with 'Bio::VertRes::Config::Recipes::Roles::Reference';
 with 'Bio::VertRes::Config::Recipes::Roles::CreateGlobal';
 with 'Bio::VertRes::Config::Recipes::Roles::BacteriaRnaSeqExpression';
 
-has 'protocol'  => ( is => 'ro', isa => 'Str',  default => 'StrandSpecificProtocol' );
+has 'protocol'  => ( is => 'ro', isa => 'Str',  default => 'StandardProtocol' );
 has '_intergenic_regions' => ( is => 'ro', isa => 'Bool', default => 1 );
 has '_no_coverage_plots'  => ( is => 'ro', isa => 'Bool', default => 0 );
 

--- a/lib/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingStampy.pm
+++ b/lib/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingStampy.pm
@@ -27,7 +27,7 @@ with 'Bio::VertRes::Config::Recipes::Roles::Reference';
 with 'Bio::VertRes::Config::Recipes::Roles::CreateGlobal';
 with 'Bio::VertRes::Config::Recipes::Roles::BacteriaRnaSeqExpression';
 
-has 'protocol'  => ( is => 'ro', isa => 'Str',  default => 'StrandSpecificProtocol' );
+has 'protocol'  => ( is => 'ro', isa => 'Str',  default => 'StandardProtocol' );
 has '_intergenic_regions' => ( is => 'ro', isa => 'Bool', default => 1 );
 has '_no_coverage_plots'  => ( is => 'ro', isa => 'Bool', default => 0 );
 has '_sequencing_file_suffix'      => ( is => 'ro', isa => 'Str',  default => 'markdup.bam' );

--- a/lib/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingTophat.pm
+++ b/lib/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingTophat.pm
@@ -27,7 +27,7 @@ with 'Bio::VertRes::Config::Recipes::Roles::Reference';
 with 'Bio::VertRes::Config::Recipes::Roles::CreateGlobal';
 with 'Bio::VertRes::Config::Recipes::Roles::BacteriaRnaSeqExpression';
 
-has 'protocol'  => ( is => 'ro', isa => 'Str',  default => 'StrandSpecificProtocol' );
+has 'protocol'  => ( is => 'ro', isa => 'Str',  default => 'StandardProtocol' );
 has 'additional_mapper_params' => ( is => 'ro', isa => 'Maybe[Str]' );
 
 has '_intergenic_regions' => ( is => 'ro', isa => 'Bool', default => 0 );

--- a/t/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingBwa.t
+++ b/t/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingBwa.t
@@ -109,7 +109,7 @@ is_deeply($input_config_file,{
             'host' => 'some_hostname'
           },
   'data' => {
-              'protocol' => 'StrandSpecificProtocol',
+              'protocol' => 'StandardProtocol',
               'annotation_file' => '/path/to/ABC.gff',
               'intergenic_regions' => 1,
               'no_coverage_plots' => 0,

--- a/t/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingSmalt.t
+++ b/t/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingSmalt.t
@@ -109,7 +109,7 @@ is_deeply($input_config_file,{
             'host' => 'some_hostname'
           },
   'data' => {
-              'protocol' => 'StrandSpecificProtocol',
+              'protocol' => 'StandardProtocol',
               'annotation_file' => '/path/to/ABC.gff',
               'intergenic_regions' => 1,
               'no_coverage_plots' => 0,

--- a/t/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingTophat.t
+++ b/t/Bio/VertRes/Config/Recipes/BacteriaRnaSeqExpressionUsingTophat.t
@@ -109,7 +109,7 @@ is_deeply($input_config_file,{
             'host' => 'some_hostname'
           },
   'data' => {
-              'protocol' => 'StrandSpecificProtocol',
+              'protocol' => 'StandardProtocol',
               'annotation_file' => '/path/to/ABC.gff',
               'intergenic_regions' => 0,
               'no_coverage_plots' => 1,


### PR DESCRIPTION
Changes the default RNA seq protocol for all bacteria from strandspecific to standard. Tests changes accordingly.