### PR TITLE
add --no_anntotation option to pacbio_register

### DIFF
--- a/lib/Bio/VertRes/Config/CommandLine/Common.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/Common.pm
@@ -196,7 +196,7 @@ sub BUILD {
     # circularise
     $self->circularise(0) if ( defined($no_circularise) );
 
-    # circularise
+    # annotate
     $self->annotate(0) if ( defined($no_annotation) );
 
     $regeneration_log_file ||= join( '/', ( $self->log_base(), 'command_line.log' ) );

--- a/lib/Bio/VertRes/Config/CommandLine/Common.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/Common.pm
@@ -79,6 +79,9 @@ has 'iva_strand_bias' => (is => 'rw', isa => 'Num', default => 0);
 # circularisation
 has 'circularise'  => ( is => 'rw', isa => 'Bool', default => 1 );
 
+# annotation
+has 'annotate' => ( is => 'rw', isa => 'Bool', default => 1 );
+
 # test mode
 has 'test_mode' => ( is => 'rw', isa => 'Bool', default => 0);
 
@@ -107,7 +110,7 @@ sub BUILD {
         $test_mode,						 $iva_qc,
         $kraken_db,	                     $iva_insert_size,
         $iva_strand_bias,				 $no_circularise,
-	$spades_opts,
+	    $spades_opts,                    $no_annotation
     );
 
     GetOptionsFromArray(
@@ -135,7 +138,7 @@ sub BUILD {
         'tophat_mapper_max_multihit=i'   => \$tophat_mapper_g,
         'tophat_mapper_library_type=s'   => \$tophat_mapper_library_type,
         'assembler=s'                    => \$assembler,
-	'spades_opts=s'                  => \$spades_opts,
+	    'spades_opts=s'                  => \$spades_opts,
         'root_base=s'                    => \$root_base,
         'log_base=s'                     => \$log_base,
         'db_file:s'                      => \$database_connect_file,
@@ -145,7 +148,8 @@ sub BUILD {
         'kraken_db=s'                    => \$kraken_db,
         'iva_insert_size=i'              => \$iva_insert_size,
         'iva_strand_bias=f'              => \$iva_strand_bias,
-        'no_circularise'		       			 => \$no_circularise,
+        'no_circularise'		       	 => \$no_circularise,
+        'no_annotation'                  => \$no_annotation,
         'h|help'                         => \$help
     );
 
@@ -191,6 +195,9 @@ sub BUILD {
     
     # circularise
     $self->circularise(0) if ( defined($no_circularise) );
+
+    # circularise
+    $self->annotate(0) if ( defined($no_annotation) );
 
     $regeneration_log_file ||= join( '/', ( $self->log_base(), 'command_line.log' ) );
     $self->regeneration_log_file($regeneration_log_file)

--- a/lib/Bio/VertRes/Config/CommandLine/PacbioRegister.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/PacbioRegister.pm
@@ -37,7 +37,7 @@ sub retrieving_results_text {
     print "Your request was SUCCESSFUL\n\n";
     print "Once the data is available you can run these commands:\n\n";
 
-    print "Create symlinks to the raw PacBio read data, final assemblies\n";
+    print "Create symlinks to the raw PacBio read data and final assemblies\n";
     print "  pf data -t " . $self->type ." -i " . $self->id . " --filetype pacbio --symlink\n\n";
     print "  pf assembly -t " . $self->type . " -i " . $self->id . " --symlink\n\n";
 

--- a/lib/Bio/VertRes/Config/CommandLine/PacbioRegister.pm
+++ b/lib/Bio/VertRes/Config/CommandLine/PacbioRegister.pm
@@ -26,7 +26,8 @@ sub run {
     
     my %mapping_parameters = %{$self->mapping_parameters};
     $mapping_parameters{'circularise'} = $self->circularise if defined ($self->circularise);
-   Bio::VertRes::Config::Recipes::PacbioRegister->new( \%mapping_parameters )->create();
+    $mapping_parameters{'annotate'} = $self->annotate if defined ($self->annotate);
+    Bio::VertRes::Config::Recipes::PacbioRegister->new( \%mapping_parameters )->create();
 
     $self->retrieving_results_text;
 };
@@ -36,9 +37,11 @@ sub retrieving_results_text {
     print "Your request was SUCCESSFUL\n\n";
     print "Once the data is available you can run these commands:\n\n";
 
-    print "Create symlinks to the raw PacBio read data, final assemblies and annotations\n";
+    print "Create symlinks to the raw PacBio read data, final assemblies\n";
     print "  pf data -t " . $self->type ." -i " . $self->id . " --filetype pacbio --symlink\n\n";
     print "  pf assembly -t " . $self->type . " -i " . $self->id . " --symlink\n\n";
+
+    print "Create symlinks to final assembly annotations\n";
     print "  pf annotation -t " . $self->type . " -i " . $self->id . " --symlink\n\n";
 
     print "Generate a report of the assembly statistics in CSV format\n";
@@ -72,6 +75,7 @@ Required:
 
 Options:
   --no_circularise  Do not circularise
+  --no_annotation   Do not annotate assembly
   -h                Print this message and exit
 
 NOTE - If you are uncertain that your request was successful, please do NOT run the command again. Instead, please direct any queries to path-help\@sanger.ac.uk.

--- a/lib/Bio/VertRes/Config/Recipes/PacbioRegister.pm
+++ b/lib/Bio/VertRes/Config/Recipes/PacbioRegister.pm
@@ -35,7 +35,7 @@ has '_memory_in_mb'		   => ( is => 'ro', isa => 'Int', default => 4000 ); # for 
 has '_target_coverage'	   => ( is => 'ro', isa => 'Int', default => 30 );
 has '_no_bsub'			   => ( is => 'ro', isa => 'Bool', default => 1 );
 has 'circularise'		   => ( is => 'ro', isa => 'Bool', default => 1 );
-
+has 'annotate'             => ( is => 'ro', isa => 'Bool', default => 1 );
 
 override '_pipeline_configs' => sub {
     my ($self) = @_;
@@ -46,7 +46,10 @@ override '_pipeline_configs' => sub {
         $self->add_hgap_assembly_config(\@pipeline_configs);
     }
 
-    $self->add_bacteria_annotate_config(\@pipeline_configs);
+    if( $self->annotate eq 1 ) 
+    {
+        $self->add_bacteria_annotate_config(\@pipeline_configs);
+    }
 
     return \@pipeline_configs;
 };

--- a/t/bin/pacbio_register.t
+++ b/t/bin/pacbio_register.t
@@ -27,6 +27,14 @@ my %scripts_and_expected_files = (
         'pathogen_pacbio_track/pathogen_pacbio_track_assembly_pipeline.conf',
         'pathogen_pacbio_track/pathogen_pacbio_track_import_cram_pipeline.conf',  
     ],
+    '-t study -i ZZZ --no_annotation' => [
+        'command_line.log',
+        'pathogen_pacbio_track/assembly/assembly_ZZZ_hgap.conf',
+        'pathogen_pacbio_track/import_cram/import_cram_global.conf',
+        'pathogen_pacbio_track/pathogen_pacbio_track.ilm.studies',       
+        'pathogen_pacbio_track/pathogen_pacbio_track_assembly_pipeline.conf',
+        'pathogen_pacbio_track/pathogen_pacbio_track_import_cram_pipeline.conf',  
+    ],
 );
 
 mock_execute_script_and_check_output_ignore_regex( $script_name, \%scripts_and_expected_files,'permission' );


### PR DESCRIPTION
Update pacbio_register:

* add --no_annotation option
* update usage
* annotate is set to 1 by default (i.e. always annotate by default)
* if --no_annotation is invoked then annotate is set to 0 and the [dbname]_annotate_assembly_pipeline.conf and a conf file in annotate_assembly do not get generated