### PR TITLE
Harmonize assembly config files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: perl
 perl:
   - "5.14"

--- a/lib/Bio/VertRes/Config/Pipelines/AnnotateAssembly.pm
+++ b/lib/Bio/VertRes/Config/Pipelines/AnnotateAssembly.pm
@@ -55,16 +55,7 @@ override 'to_hash' => sub {
     $output_hash->{limit}                   = $self->_limit;
     $output_hash->{max_lanes_to_search}     = $self->_max_lanes_to_search;
     $output_hash->{max_failures}            = $self->_max_failures;
-    
-    if($self->_assembler eq 'velvet')
-    {
-        $output_hash->{vrtrack_processed_flags} = { assembled => 1, annotated => 0 };
-    }
-    else
-    {
-    	$output_hash->{vrtrack_processed_flags} = { assembled => 1};
-    }
-    
+    $output_hash->{vrtrack_processed_flags} = { assembled => 1};
     $output_hash->{limits}                  = $self->_escaped_limits;
 
     $output_hash->{data}{tmp_directory}     = $self->_tmp_directory;

--- a/lib/Bio/VertRes/Config/Recipes/BacteriaAssemblyAndAnnotation.pm
+++ b/lib/Bio/VertRes/Config/Recipes/BacteriaAssemblyAndAnnotation.pm
@@ -24,7 +24,7 @@ has '_remove_primers'      => ( is => 'ro', isa => 'Bool', default => 0 );
 has '_pipeline_version'    => ( is => 'ro', isa => 'Str' );
 has '_normalise'           => ( is => 'ro', isa => 'Bool', default => 0 );
 has '_kingdom'             => ( is => 'ro', isa => 'Str',  default => "Bacteria" );
-has '_vrtrack_processed_flags'    => ( is => 'ro', isa => 'HashRef', default => sub {{ assembled => 0, qc => 1, rna_seq_expression => 0 }} );
+has '_vrtrack_processed_flags'    => ( is => 'ro', isa => 'HashRef', default => sub {{ qc => 1, rna_seq_expression => 0 }} );
 has 'iva_qc'			   => ( is => 'ro', isa => 'Bool', default => 0 );
 has 'kraken_db'		   => ( is => 'ro', isa => 'Str',  default => "/lustre/scratch118/infgen/pathogen/pathpipe/kraken/assemblyqc_fluhiv_20150728" );
 has 'spades_opts'         => ( is => 'ro', isa => 'Str',  default => ' --careful --cov-cutoff auto ' );

--- a/lib/Bio/VertRes/Config/Recipes/BacteriaRegisterAndQCStudy.pm
+++ b/lib/Bio/VertRes/Config/Recipes/BacteriaRegisterAndQCStudy.pm
@@ -30,7 +30,7 @@ has '_remove_primers'      => ( is => 'ro', isa => 'Bool', default => 0 );
 has '_pipeline_version'    => ( is => 'ro', isa => 'Str' );
 has '_normalise'           => ( is => 'ro', isa => 'Bool', default => 0 );
 has '_kingdom'             => ( is => 'ro', isa => 'Str',  default => "Bacteria" );
-has '_vrtrack_processed_flags'    => ( is => 'ro', isa => 'HashRef', default => sub {{ assembled => 0, qc => 1, rna_seq_expression => 0 }} );
+has '_vrtrack_processed_flags'    => ( is => 'ro', isa => 'HashRef', default => sub {{ qc => 1, rna_seq_expression => 0 }} );
 has 'iva_qc'			   => ( is => 'ro', isa => 'Bool', default => 0 );
 has 'kraken_db'		   => ( is => 'ro', isa => 'Str',  default => "/lustre/scratch118/infgen/pathogen/pathpipe/kraken/assemblyqc_fluhiv_20150728" );
 has 'spades_opts'         => ( is => 'ro', isa => 'Str',  default => ' --careful --cov-cutoff auto ' );

--- a/lib/Bio/VertRes/Config/Recipes/Roles/BacteriaRegisterStudy.pm
+++ b/lib/Bio/VertRes/Config/Recipes/Roles/BacteriaRegisterStudy.pm
@@ -78,7 +78,6 @@ sub add_bacteria_velvet_assembly_config
           _error_correct                 => $self->_error_correct,
           _remove_primers                => $self->_remove_primers,
           _normalise                     => $self->_normalise,
-          _vrtrack_processed_flags       => $self->_vrtrack_processed_flags,
           iva_qc						 => $self->iva_qc,
           kraken_db				     => $self->kraken_db,
       )

--- a/t/Bio/VertRes/Config/Pipelines/AnnotateAssembly.t
+++ b/t/Bio/VertRes/Config/Pipelines/AnnotateAssembly.t
@@ -61,8 +61,7 @@ is_deeply(
                         },
               'max_lanes_to_search' => 10000,
               'vrtrack_processed_flags' => {
-                                             'assembled' => 1,
-                                             'annotated' => 0
+                                             'assembled' => 1
                                            },
               'root' => '/path/to/root/my_database/seq-pipelines',
               'log' => '/path/to/log/my_database/annotate_assembly_Abc_def_ghi123_velvet.log',

--- a/t/Bio/VertRes/Config/Recipes/BacteriaAssemblyAndAnnotation.t
+++ b/t/Bio/VertRes/Config/Recipes/BacteriaAssemblyAndAnnotation.t
@@ -75,7 +75,6 @@ is_deeply($input_config_file,{
                              ]
               },
   'vrtrack_processed_flags' => { 
-                                 'assembled' => 0,
                                  'rna_seq_expression' => 0,
                                  'qc' => 1
                                },
@@ -127,8 +126,7 @@ is_deeply($input_config_file,{
                              ]
               },
   'vrtrack_processed_flags' => {
-                                 'assembled' => 1,
-                                 'annotated' => 0
+                                 'assembled' => 1
                                },
   'root' => '/lustre/scratch118/infgen/pathogen/pathpipe/my_database/seq-pipelines',
   'log' => '/nfs/pathnfs05/log/my_database/annotate_assembly_ABC_study_EFG_velvet.log',

--- a/t/Bio/VertRes/Config/Recipes/BacteriaRegisterAndQCStudy.t
+++ b/t/Bio/VertRes/Config/Recipes/BacteriaRegisterAndQCStudy.t
@@ -139,7 +139,6 @@ is_deeply($input_config_file,{
                              ]
               },
   'vrtrack_processed_flags' => {
-                                 'assembled' => 0,
                                  'rna_seq_expression' => 0,
                                  'qc' => 1
                                },
@@ -191,8 +190,7 @@ is_deeply($input_config_file,{
                              ]
               },
   'vrtrack_processed_flags' => {
-                                 'assembled' => 1,
-                                 'annotated' => 0
+                                 'assembled' => 1
                                },
   'root' => '/lustre/scratch118/infgen/pathogen/pathpipe/my_database/seq-pipelines',
   'log' => '/nfs/pathnfs05/log/my_database/annotate_assembly_ABC_study_EFG_velvet.log',


### PR DESCRIPTION
This should remove the discrepancy between assembly with velvet and spades (and other assemblers). Currently velvet will only run reliably if no assembly with another tool has run before.

Also fixing tests by requiring Ubuntu 14.04 as base. Perl 5.14 is not available for Ubunutu 16.04, which is now the Travis standard.