### PR TITLE
Remove admin approval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: perl
 perl:
-  - "5.14"
+  - "5.26.1"
 sudo: false
 install:
   - "cpanm Dist::Zilla"

--- a/lib/Bio/VertRes/Config/MultipleTopLevelFiles.pm
+++ b/lib/Bio/VertRes/Config/MultipleTopLevelFiles.pm
@@ -23,7 +23,6 @@ sub update_or_create {
     my ($self) = @_;
 
     my %short_name_to_configs;
-    my %configs_requiring_approval;
 
     # split by short name
     for my $pipeline_config ( @{ $self->pipeline_configs } ) {
@@ -43,28 +42,11 @@ sub update_or_create {
             config_base => $self->config_base
         );
         $toplevel_config->update_or_create();
-
-       # Does an admin email need to be sent telling them about config files which need approval?
-       if( $toplevel_config->admin_email_needs_to_be_sent == 1 )
-       {
-         $configs_requiring_approval{$toplevel_config->overall_config}++;
-       }
-
-    }
-    
-    if(keys %configs_requiring_approval > 0)
-    {
-      $self->email_admins_for_approval(\%configs_requiring_approval);
     }
     
     return $self;
 }
 
-sub email_admins_for_approval
-{
-  my ($self,$files_requiring_approval) = @_;
-  1;
-}
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/Bio/VertRes/Config/Pipelines/Common.pm
+++ b/lib/Bio/VertRes/Config/Pipelines/Common.pm
@@ -30,7 +30,6 @@ has 'octal_permissions'   => ( is => 'ro', isa => 'Num',                        
 has 'pipeline_short_name' => ( is => 'ro', isa => 'Str',                          required => 1 );
 has 'module'              => ( is => 'ro', isa => 'Str',                          required => 1 );
 has 'toplevel_action'     => ( is => 'ro', isa => 'Str',                          required => 1 );
-has 'toplevel_admin_approval_required'   => ( is => 'ro', isa => 'Bool', default => 0 );
 
 has 'overwrite_existing_config_file' => ( is => 'ro', isa => 'Bool', default => 0 );
 

--- a/lib/Bio/VertRes/Config/Pipelines/Mapping.pm
+++ b/lib/Bio/VertRes/Config/Pipelines/Mapping.pm
@@ -36,7 +36,6 @@ has 'module'                => ( is => 'ro', isa => 'Str', default  => 'VertRes:
 has 'reference'             => ( is => 'ro', isa => 'Str', required => 1 );
 has 'reference_lookup_file' => ( is => 'ro', isa => 'Str', required => 1 );
 has 'toplevel_action'       => ( is => 'ro', isa => 'Str', default => '__VRTrack_Mapping__' );
-has 'toplevel_admin_approval_required'   => ( is => 'ro', isa => 'Bool', default => 1 );
 
 has 'slx_mapper'            => ( is => 'ro', isa => 'Str', required => 1 );
 has 'slx_mapper_exe'        => ( is => 'ro', isa => 'Str', required => 1 );

--- a/lib/Bio/VertRes/Config/Pipelines/RnaSeqExpression.pm
+++ b/lib/Bio/VertRes/Config/Pipelines/RnaSeqExpression.pm
@@ -35,7 +35,6 @@ has 'module'              => ( is => 'ro', isa => 'Str', default  => 'VertRes::P
 has 'reference'           => ( is => 'ro', isa => 'Str', required => 1 );
 has 'reference_lookup_file' =>  ( is => 'ro', isa => 'Str', required => 1 );
 has 'toplevel_action'       => ( is => 'ro', isa => 'Str', default => '__VRTrack_RNASeqExpression__' );
-has 'toplevel_admin_approval_required'   => ( is => 'ro', isa => 'Bool', default => 1 );
 
 has '_annotation_file'             => ( is => 'ro', isa => 'Str', lazy => 1, builder => '_build__annotation_file' );
 has '_sequencing_file_suffix'      => ( is => 'ro', isa => 'Str',  default => 'markdup.bam' );

--- a/lib/Bio/VertRes/Config/Pipelines/SnpCalling.pm
+++ b/lib/Bio/VertRes/Config/Pipelines/SnpCalling.pm
@@ -36,7 +36,6 @@ has 'reference'           => ( is => 'ro', isa => 'Str', required => 1 );
 has 'reference_lookup_file' =>  ( is => 'ro', isa => 'Str', required => 1 );
 has 'toplevel_action'       => ( is => 'ro', isa => 'Str', default => '__VRTrack_SNPs__' );
 has 'run_after_bam_improvement' => ( is => 'ro', isa => 'Bool', default => 0);
-has 'toplevel_admin_approval_required'   => ( is => 'ro', isa => 'Bool', default => 1 );
 
 has '_max_lanes'     => ( is => 'ro', isa => 'Int',  default => 300 );
 has '_pseudo_genome' => ( is => 'ro', isa => 'Bool', default => 1 );

--- a/lib/Bio/VertRes/Config/TopLevel.pm
+++ b/lib/Bio/VertRes/Config/TopLevel.pm
@@ -22,9 +22,6 @@ has 'pipeline_short_name' => ( is => 'ro', isa => 'Str', required => 1 );
 has 'database'            => ( is => 'ro', isa => 'Str', required => 1 );
 has 'pipeline_configs'    => ( is => 'ro', isa => 'ArrayRef', required => 1 );
 
-has '_admin_approval_prefix'    => ( is => 'ro', isa => 'Str', default => '#admin_approval_required#' );
-has 'admin_email_needs_to_be_sent'    => ( is => 'rw', isa => 'Bool', default => 0 );
-
 has 'overall_config'                   => ( is => 'ro', isa => 'Str',     lazy    => 1, builder => '_build_overall_config' );
 has 'config_base'              => ( is => 'ro', isa => 'Str',     required => 1 );
 has 'overall_config_file_name'         => ( is => 'ro', isa => 'Str',     lazy    => 1, builder => '_build_overall_config_file_name' );
@@ -66,19 +63,8 @@ sub _build__filenames_to_action {
     
     for my $pipeline_config (@{$self->pipeline_configs})
     {
-      
       next if($preexisting_filenames{$pipeline_config->config});
-
-      # comment out the action if it requires admin approval
-      if($pipeline_config->toplevel_admin_approval_required == 1)
-      {
-        $filenames_to_action{$pipeline_config->config} = $self->_admin_approval_prefix.$pipeline_config->toplevel_action;
-        $self->admin_email_needs_to_be_sent(1);
-      }
-      else
-      {
-        $filenames_to_action{$pipeline_config->config} = $pipeline_config->toplevel_action;
-      }
+      $filenames_to_action{$pipeline_config->config} = $pipeline_config->toplevel_action;
     }
     
     return \%filenames_to_action;

--- a/t/Bio/VertRes/Config/MultipleTopLevelFiles.t
+++ b/t/Bio/VertRes/Config/MultipleTopLevelFiles.t
@@ -81,8 +81,8 @@ ok(-e $destination_directory.'/my_database/my_database_snps_pipeline.conf', 'snp
 my $text = read_text( $destination_directory.'/my_database/my_database_mapping_pipeline.conf' );
 chomp($text);
 my @mapping_rows = sort(split("\n",$text));
-is_deeply(\@mapping_rows , ["#admin_approval_required#__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_bwa.conf",
-"#admin_approval_required#__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_smalt.conf"], 'content of mapping toplevel file as expected');
+is_deeply(\@mapping_rows , ["__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_bwa.conf",
+"__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_smalt.conf"], 'content of mapping toplevel file as expected');
 
 $text = read_text( $destination_directory.'/my_database/my_database_stored_pipeline.conf' );
 chomp($text);
@@ -94,7 +94,7 @@ is($text, "__VRTrack_Import_cram__ $destination_directory/my_database/import_cra
 
 $text = read_text( $destination_directory.'/my_database/my_database_snps_pipeline.conf' );
 chomp($text);
-is($text, "#admin_approval_required#__VRTrack_SNPs__ $destination_directory/my_database/snps/snps_XYZ_study_EFG_ABC.conf", 'content of snps toplevel file as expected');
+is($text, "__VRTrack_SNPs__ $destination_directory/my_database/snps/snps_XYZ_study_EFG_ABC.conf", 'content of snps toplevel file as expected');
 
 done_testing();
 

--- a/t/Bio/VertRes/Config/TopLevel.t
+++ b/t/Bio/VertRes/Config/TopLevel.t
@@ -60,8 +60,8 @@ ok(-e $destination_directory.'/my_database/my_database_mapping_pipeline.conf', '
 my $text = read_text( $destination_directory.'/my_database/my_database_mapping_pipeline.conf' );
 chomp($text);
 my @mapping_rows = sort(split("\n",$text));
-is_deeply(\@mapping_rows , ["#admin_approval_required#__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_bwa.conf",
-"#admin_approval_required#__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_smalt.conf"], 'content of mapping toplevel file as expected');
+is_deeply(\@mapping_rows , ["__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_bwa.conf",
+"__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_smalt.conf"], 'content of mapping toplevel file as expected');
 
 
 # Running it again should produce the same output
@@ -75,8 +75,8 @@ ok(($obj_rerun->update_or_create()), 'Create the toplevel file thats been rerun'
 $text = read_text( $destination_directory.'/my_database/my_database_mapping_pipeline.conf' );
 chomp($text);
 @mapping_rows = sort(split("\n",$text));
-is_deeply(\@mapping_rows , ["#admin_approval_required#__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_bwa.conf",
-"#admin_approval_required#__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_smalt.conf"], 'content of mapping toplevel file as expected, so no duplicates');
+is_deeply(\@mapping_rows , ["__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_bwa.conf",
+"__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_smalt.conf"], 'content of mapping toplevel file as expected, so no duplicates');
 
 
 # Append a new mapping
@@ -101,9 +101,9 @@ $text = read_text( $destination_directory.'/my_database/my_database_mapping_pipe
 chomp($text);
 @mapping_rows = sort(split("\n",$text));
 is_deeply(\@mapping_rows , [
-  "#admin_approval_required#__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_bwa.conf",
-  "#admin_approval_required#__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_smalt.conf",
-  "#admin_approval_required#__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_Another_study_ABC_stampy.conf"
+  "__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_bwa.conf",
+  "__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_ABC_study_EFG_ABC_smalt.conf",
+  "__VRTrack_Mapping__ $destination_directory/my_database/mapping/mapping_Another_study_ABC_stampy.conf"
 ], 'content of mapping toplevel file has the appended row');
 
 


### PR DESCRIPTION
To remove admin approval comment from config files when requesting a run of Mapping/SNP calling/RNAseq pipelines.

Lines added to the config file are currently commented out with a flag saying "admin approval required". This was necessary when the scripts where run by users, but is cumbersome now that they are only run by members of Pathogen Informatics.

As per https://trello.com/c/i269oWqa